### PR TITLE
sample app documentation updates

### DIFF
--- a/IAC/Terraform/SAMPLE_APP_ARCHITECTURE.md
+++ b/IAC/Terraform/SAMPLE_APP_ARCHITECTURE.md
@@ -151,3 +151,35 @@ terraform apply "${environment}_l02_d01.tfplan"
 ```
 
 > Above command uses the `backend.tfvars` file that was created in the previos step, to access the _Remote State Storage_ (_Azure Storage Account_) and save the state there.
+
+Finally, modify as needed and run the below command in the [03_webapp/01_deployment](./terraform/03_webapp/01_deployment) folder to deploy the webapp layer;
+
+```bash
+location="eastus"
+environment="dev"
+project_name="<UNIQUE_PROJECT_NAME>"
+resource_group_name="rg-tf-remote-state-${environment}"
+storage_account_name="tfrs${project_name}${environment}"
+container_name="tfstate"
+docker_image_name="eshop/webmvc"
+app_service_sku_size="S1"
+app_service_sku_tier="Standard"
+
+terraform init -backend-config="../../backend.tfvars" -upgrade
+
+terraform plan \
+  -var "location=${location}" \
+  -var "environment=${environment}" \
+  -var "project_name=${project_name}" \
+  -var "resource_group_name=${resource_group_name}" \
+  -var "storage_account_name=${storage_account_name}" \
+  -var "container_name=${container_name}" \
+  -var "docker_image_name=${docker_image_name}" \
+  -var "app_service_sku_size=${app_service_sku_size}" \
+  -var "app_service_sku_tier=${app_service_sku_tier}" \
+  -out "${environment}_l03_d01.tfplan"
+
+terraform apply "${environment}_l03_d01.tfplan"
+```
+
+> Above command uses the `backend.tfvars` file that was created in the previos step, to access the _Remote State Storage_ (_Azure Storage Account_) and save the state there.


### PR DESCRIPTION
Adding sample scripts to guide the user to successfully deploy the sample project

As we talked a bit on the standup, source code of the sample project doesn't have to be in the symphony repo. In fact, having the sample project in a docker container simplifies and make the repo more _clean_

Also, removing the sample project source code solves syncing problems too, like, who will sync the source code if the official eShopOnWeb has updates, etc.

We'll be able to remove the extra 2 bash scripts that migrates the database schema and populate the sample data to the database, since those steps are already baked into the docker container. Removing those 2 bash scripts make the terraform and bicep modules more similar, since bicep doesn't have script execution capabilities yet.

Source of the eShopOnWeb project will be updated in the document, as we don't have an official image deployed to either Docker hub, or, Microsoft Container Registry.

When we have the image deployed to mcr, this document will be updated and apps folder will be removed.

_Note: a PR is created on the eShopOnWeb repo to fix some devcontainer issues, but it's not a blocker if we don't see the PR merged._