### PR TITLE
fixing github cli version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -93,7 +93,7 @@
 		// 	"terragrunt": "0.36.3"
 		// },
 		"git": "os-provided",
-		"github-cli": "2.5.2",
+		"github-cli": "latest",
 		// "azure-cli": "2.34.1",
 		// "golang": "1.17.8",
 		"powershell": "7.2.1",


### PR DESCRIPTION
devcontainer creation fails when it installs github cli feature, because version 2.5.2 is not found.

here is the devcontainer creation log

```log
2022-04-22 17:49:52.403Z: 
2022-04-22 17:49:52.417Z: #7 22.48 Docker / Moby CLI already installed.
2022-04-22 17:49:52.544Z: #7 22.48 Docker Compose already installed.
2022-04-22 17:49:52.558Z: #7 22.48 (*) Script: github-debian.sh 2.5.2
2022-04-22 17:49:52.852Z: #7 22.79 CLI_VERSION=2.5.2
2022-04-22 17:49:52.870Z: #7 22.79 Downloading github CLI...
2022-04-22 17:49:53.609Z: #7 23.56 GITHUB_CLI_ARCHIVE_GPG_KEY=C99B11DEB97541F0
2022-04-22 17:49:53.626Z: #7 23.56 GPG_KEY_SERVERS=keyserver hkp://keyserver.ubuntu.com:80
2022-04-22 17:49:53.646Z: #7 23.56 keyserver hkps://keys.openpgp.org
2022-04-22 17:49:53.660Z: #7 23.56 keyserver hkp://keyserver.pgp.com
2022-04-22 17:49:53.678Z: #7 23.57 (*) Downloading GPG key...
2022-04-22 17:49:54.196Z: #7 24.21 Hit:1 http://security.debian.org/debian-security bullseye-security InRelease
2022-04-22 17:49:54.216Z: #7 24.26 Hit:2 http://deb.debian.org/debian bullseye InRelease
2022-04-22 17:49:54.336Z: #7 24.27 Hit:3 http://deb.debian.org/debian bullseye-updates InRelease
2022-04-22 17:49:54.351Z: #7 24.31 Hit:4 https://packages.microsoft.com/repos/azure-cli bullseye InRelease
2022-04-22 17:49:54.365Z: #7 24.32 Get:5 https://cli.github.com/packages bullseye InRelease [3747 B]
2022-04-22 17:49:54.381Z: #7 24.33 Hit:6 https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye InRelease
2022-04-22 17:49:54.645Z: #7 24.65 Get:7 https://cli.github.com/packages bullseye/main amd64 Packages [337 B]
2022-04-22 17:49:54.660Z: #7 24.66 Fetched 4084 B in 0s (8520 B/s)
2022-04-22 17:49:54.675Z: #7 24.66 Reading package lists...
2022-04-22 17:49:55.037Z: 
2022-04-22 17:49:55.175Z: #7 25.15 Reading package lists...
2022-04-22 17:49:55.652Z: 
2022-04-22 17:49:55.667Z: #7 25.63 Building dependency tree...
2022-04-22 17:49:55.792Z: 
2022-04-22 17:49:56.589Z: #7 25.73 Reading state information...
2022-04-22 17:49:56.619Z: #7 25.81 E: Version '2.5.2' for 'gh' was not found
2022-04-22 17:49:56.717Z: #7 ERROR: executor failed running [/bin/sh -c cd /tmp/build-features/local-cache && chmod +x ./install.sh && ./install.sh]: exit code: 100
2022-04-22 17:49:56.744Z: ------
2022-04-22 17:49:56.768Z:  > [3/3] RUN cd /tmp/build-features/local-cache && chmod +x ./install.sh && ./install.sh:
2022-04-22 17:49:56.785Z: ------
2022-04-22 17:49:56.805Z: executor failed running [/bin/sh -c cd /tmp/build-features/local-cache && chmod +x ./install.sh && ./install.sh]: exit code: 100
2022-04-22 17:49:56.836Z: Error: Command failed: docker build -t vsc-symphony-c0438650893d480685f8c18695baeb41-features --build-arg BASE_IMAGE=vsc-symphony-c0438650893d480685f8c18695baeb41 --build-arg IMAGE_USER=root /tmp/vsch/container-features/0.60.1-1650649767130
2022-04-22 17:49:56.870Z:     at u8 (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/node/devContainersCLI.js:357:7580)
2022-04-22 17:49:56.914Z:     at wL (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/node/devContainersCLI.js:357:5265)
2022-04-22 17:49:56.958Z:     at async jue (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/node/devContainersCLI.js:351:10501)
2022-04-22 17:49:57.000Z:     at async _J (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/node/devContainersCLI.js:386:3257)
2022-04-22 17:49:57.029Z:     at async B8e (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/node/devContainersCLI.js:386:22966)
2022-04-22 17:49:57.081Z:     at async $8e (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/node/devContainersCLI.js:386:22570)
2022-04-22 17:49:57.113Z: Stop (29477 ms): Run: docker build -t vsc-symphony-c0438650893d480685f8c18695baeb41-features --build-arg BASE_IMAGE=vsc-symphony-c0438650893d480685f8c18695baeb41 --build-arg IMAGE_USER=root /tmp/vsch/container-features/0.60.1-1650649767130
2022-04-22 17:49:57.159Z: Failed to create container.
2022-04-22 17:49:57.199Z: Error: Command failed: docker build -t vsc-symphony-c0438650893d480685f8c18695baeb41-features --build-arg BASE_IMAGE=vsc-symphony-c0438650893d480685f8c18695baeb41 --build-arg IMAGE_USER=root /tmp/vsch/container-features/0.60.1-1650649767130
2022-04-22 17:49:57.225Z: Error Code: 1302
2022-04-22 17:49:57.243Z: Container creation failed.
```

and here is the screenshot

![image](https://user-images.githubusercontent.com/118744/164771814-fcb23215-b406-4a46-8075-a7c1f256e1af.png)
