### PR TITLE
making agent pool parameterized

### DIFF
--- a/.azure-pipelines/pipeline.ci.bicep.yml
+++ b/.azure-pipelines/pipeline.ci.bicep.yml
@@ -11,7 +11,7 @@ variables:
   # The following Variables should be set on the pipeline level #
   #=============================================================#
 
-  - name: poolName
+  - name: agentImage
     value: "ubuntu-latest"
 
   - name: environmentName
@@ -30,7 +30,7 @@ variables:
     value: ","
 
 pool:
-  vmImage: $(poolName)
+  vmImage: $(agentImage)
 
 jobs:
   - template: ./template.bicep.validate.yml

--- a/.azure-pipelines/pipeline.ci.terraform.yml
+++ b/.azure-pipelines/pipeline.ci.terraform.yml
@@ -7,7 +7,7 @@ pr:
   - none
 
 variables:
-  - name: poolName
+  - name: agentImage
     value: "ubuntu-latest"
 
   - name: workDir
@@ -40,7 +40,7 @@ variables:
     value: "1.1.7"
 
 pool:
-  vmImage: $(poolName)
+  vmImage: $(agentImage)
 
 stages:
   - stage: Validate

--- a/.azure-pipelines/pipeline.destroy.bicep.yml
+++ b/.azure-pipelines/pipeline.destroy.bicep.yml
@@ -12,7 +12,7 @@ variables:
   #=============================================================#
 
   # Name of the Agent Pool to use
-  - name: poolName
+  - name: agentImage
     value: "ubuntu-latest"
 
   # Name of the Environment
@@ -32,7 +32,7 @@ variables:
     value: "kv-symphony-env"
 
 pool:
-  vmImage: $(poolName)
+  vmImage: $(agentImage)
 
 jobs:
   - template: ./template.bicep.destroy.yml


### PR DESCRIPTION
in order to support more scenarios that might use different kind of agents, agent pool name is parameterized

latest execution of the CI Bicep pipeline can be found in https://dev.azure.com/csedevops/Symphony/_build/results?buildId=15143&view=logs&j=92058b04-f16a-5035-546c-cae3ad5e2f5f&t=7d5b48e7-757e-5085-8d5e-45465566a194

in the project I'm working on currently, I'll receive the name of the agent pool that the pipelines should run on. instead of changing the pool name specific to that project, I'm creating this PR to support similar scenarios.

in that specific project, pipelines should run on hosted agents, instead of cloud agents, to configured to be able to access on-prem networks.