### PR TITLE
adding variable group support

### DIFF
--- a/.azure-pipelines/pipeline.ci.bicep.yml
+++ b/.azure-pipelines/pipeline.ci.bicep.yml
@@ -6,12 +6,6 @@ trigger:
 pr:
   - none
 
-variables:
-  - group: ${{ parameters.environmentName }}
-
-  - name: agentImage
-    value: "ubuntu-latest"
-
 parameters:
   - name: environmentName
     default: "dev"
@@ -28,16 +22,36 @@ parameters:
   - name: excludedFolders
     default: ","
 
+variables:
+  - group: ${{ parameters.environmentName }}
+
+  - name: agentImage
+    value: "ubuntu-latest"
+
 pool:
   vmImage: $(agentImage)
 
 jobs:
-  - job: xyz
-    steps:
-    - task: Bash@3
-      displayName: "test variable group"
-      inputs:
-        failOnStderr: true
-        targetType: "inline"
-        script: |
-          echo "variablegroup1: $(variablegroup1)"
+  - template: ./template.bicep.validate.yml
+    parameters:
+      environmentName: $(environmentName)
+      locationName: $(locationName)
+      keyVaultArmSvcConnectionName: $(keyVaultArmSvcConnectionName)
+      keyVaultName: $(keyVaultName)
+      excludedFolders: $(excludedFolders)
+
+  - template: ./template.bicep.previewdeploy.yml
+    parameters:
+      environmentName: $(environmentName)
+      locationName: $(locationName)
+      keyVaultArmSvcConnectionName: $(keyVaultArmSvcConnectionName)
+      keyVaultName: $(keyVaultName)
+      excludedFolders: $(excludedFolders)
+
+  - template: ./template.bicep.test.yml
+    parameters:
+      environmentName: $(environmentName)
+      locationName: $(locationName)
+      keyVaultArmSvcConnectionName: $(keyVaultArmSvcConnectionName)
+      keyVaultName: $(keyVaultName)
+      excludedFolders: $(excludedFolders)

--- a/.azure-pipelines/pipeline.ci.terraform.yml
+++ b/.azure-pipelines/pipeline.ci.terraform.yml
@@ -6,69 +6,59 @@ trigger:
 pr:
   - none
 
+parameters:
+  - name: environmentName
+    default: "dev"
+
+  - name: keyVaultArmSvcConnectionName
+    default: "Symphony-KV"
+
+  - name: keyVaultName
+    default: "kv-symphony-env"
+
 variables:
   - name: agentImage
     value: "ubuntu-latest"
 
   - name: workDir
     value: "$(System.DefaultWorkingDirectory)/IAC/Terraform/terraform"
+
   - name: runBackupState
     value: true
 
-  #=============================================================#
-  # The following Variables should be set on the pipeline level #
-  #=============================================================#
-
-  # Name of the Environment
-  - name: environmentName
-    value: "dev"
-
-  # ARM Service Connection Name used for environment Key Vault access
-  - name: keyVaultArmSvcConnectionName
-    value: "Symphony-KV"
-
-  # Environment Key Vault Name
-  - name: keyVaultName
-    value: "kv-symphony-env"
-
-  # Go Lang version
   - name: goVersion
     value: "1.18.1"
 
-  # Terraform version
   - name: terraformVersion
     value: "1.1.7"
 
 pool:
   vmImage: $(agentImage)
 
-stages:
-  - stage: Validate
-    displayName: "Validate Configuration"
-    jobs:
-      - template: ./template.terraform.validate.yml
-        parameters:
-          goVersion: "$(goVersion)"
-          terraformVersion: "$(terraformVersion)"
-          keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
-          keyVaultName: "$(keyVaultName)"
-          runLayerTest: "false"
+jobs:
+  - template: ./template.terraform.validate.yml
+    parameters:
+      goVersion: "$(goVersion)"
+      terraformVersion: "$(terraformVersion)"
+      keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
+      keyVaultName: "$(keyVaultName)"
+      runLayerTest: "false"
 
-      - template: ./template.terraform.previewdeploy.yml
-        parameters:
-          goVersion: "$(goVersion)"
-          terraformVersion: "$(terraformVersion)"
-          keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
-          keyVaultName: "$(keyVaultName)"
+  - template: ./template.terraform.previewdeploy.yml
+    parameters:
+      goVersion: "$(goVersion)"
+      terraformVersion: "$(terraformVersion)"
+      keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
+      keyVaultName: "$(keyVaultName)"
 
-      - template: ./template.terraform.test.yml
-        parameters:
-          goVersion: "$(goVersion)"
-          terraformVersion: "$(terraformVersion)"
-          keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
-          keyVaultName: "$(keyVaultName)"
+  - template: ./template.terraform.test.yml
+    parameters:
+      goVersion: "$(goVersion)"
+      terraformVersion: "$(terraformVersion)"
+      keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
+      keyVaultName: "$(keyVaultName)"
 
-      - template: ./template.terraform.report.yml
-        parameters:
-          keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
-          keyVaultName: "$(keyVaultName)"
+  - template: ./template.terraform.report.yml
+    parameters:
+      keyVaultArmSvcConnectionName: "$(keyVaultArmSvcConnectionName)"
+      keyVaultName: "$(keyVaultName)"

--- a/.azure-pipelines/pipeline.destroy.bicep.yml
+++ b/.azure-pipelines/pipeline.destroy.bicep.yml
@@ -6,30 +6,22 @@ trigger:
 pr:
   - none
 
-variables:
-  #=============================================================#
-  # The following Variables should be set on the pipeline level #
-  #=============================================================#
+parameters:
+  - name: environmentName
+    default: "dev"
 
-  # Name of the Agent Pool to use
+  - name: locationName
+    default: "westus"
+
+  - name: keyVaultArmSvcConnectionName
+    default: "Symphony-KV"
+
+  - name: keyVaultName
+    default: "kv-symphony-env"
+
+variables:
   - name: agentImage
     value: "ubuntu-latest"
-
-  # Name of the Environment
-  - name: environmentName
-    value: "dev"
-
-  # Name of the deployment Location
-  - name: locationName
-    value: "westus"
-
-  # ARM Service Connection Name used for environment Key Vault access
-  - name: keyVaultArmSvcConnectionName
-    value: "Symphony-KV"
-
-  # Environment Key Vault Name
-  - name: keyVaultName
-    value: "kv-symphony-env"
 
 pool:
   vmImage: $(agentImage)


### PR DESCRIPTION
currently, symphony gets environment related values from the assigned _keyvault_ instance, by the following sample codes in the pipelines;

- https://github.com/microsoft/symphony/blob/main/.azure-pipelines/pipeline.ci.bicep.yml#L23

- https://github.com/microsoft/symphony/blob/main/.azure-pipelines/template.bicep.validate.yml#L35

project I'm working on currently uses _Azure DevOps Variable Groups_, instead of getting variables from a _KeyVault_ instance

in order to add _variable group_ support to symphony (_beside the KeyVault support_), I converted some of the `variables` as `parameters` in pipelines and added `group` structure into the `variables` structure

with this change, _variables_ inside the _variable group_ with the same name as the value of the `environmentName` parameter will be bind to the execution the pipeline.

you can see the example execution in the below;

https://dev.azure.com/csedevops/Symphony/_build/results?buildId=15155&view=logs&j=b51504af-0b4d-5229-17c8-7992021d9f92&t=5ded3e51-2bf1-5ea6-924a-ae36be5a5ef3
