### PR TITLE
fix AzureChinaCloud arm environment value

### DIFF
--- a/scripts/orchestrators/_helpers.sh
+++ b/scripts/orchestrators/_helpers.sh
@@ -29,7 +29,7 @@ azlogin() {
     elif [ "${cloud_name}" == 'AzureUSGovernment' ]; then
         export ARM_ENVIRONMENT="usgovernment"
     elif [ "${cloud_name}" == 'AzureChinaCloud' ]; then
-        export ARM_ENVIRONMENT="usgovernment"
+        export ARM_ENVIRONMENT="china"
     elif [ "${cloud_name}" == 'AzureGermanCloud' ]; then
         export ARM_ENVIRONMENT="german"
     else


### PR DESCRIPTION
Fixing the ARM_ENVIRONMENT value for AzureChinaCloud [doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#environment)

Note: did not run the CI since we do not have accounts to test for nonpublic cloud