### PR TITLE
Fixing Bicep Validate Error

### DIFF
--- a/scripts/install/cli/symphony
+++ b/scripts/install/cli/symphony
@@ -95,7 +95,7 @@ configure_orchestrator() {
 
     # workflow
     TARGET_ROOT=$(mktemp -d)
-    cp -R . "$TARGET_ROOT"
+    cp -R "$REPO_DIR" "$TARGET_ROOT"
 
     pushd "$TARGET_ROOT" || exit
         rm -rf .git

--- a/scripts/orchestrators/iac.bicep.validate.sh
+++ b/scripts/orchestrators/iac.bicep.validate.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 source ./iac.bicep.sh
+source ../utilities/os.sh
+
 azlogin "${ARM_SUBSCRIPTION_ID}" "${ARM_TENANT_ID}" "${ARM_CLIENT_ID}" "${ARM_CLIENT_SECRET}" 'AzureCloud'
 
 pushd .


### PR DESCRIPTION
This PR addresses the following:

- Fixes an error during the Bicep Validate process. This error was due to print statements in the validate method that are returned along with the output json. This was causing jq to throw an error.
- A change to the bicep_output_to_env. Because of multiple pipes, non zero error codes where not being handled resulting a pipeline success, even if there was an error in the output json. This was fixed by using PIPESTATUS.
- There was a minor issue with the symphony cli in that unless it was run from a project root, it would not copy the correct content. A change was made to ensure pipeline config always copies from the current project root.