### PR TITLE
GitHub PAT bug fix & missing symphony.json fix

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -11,9 +11,8 @@ Symphony offers a CLI to perform several actions that bootstraps a new IAC proje
   For GitHub:
   - Install [GitHub Cli](https://docs.github.com/en/github-cli/github-cli/about-github-cli).
   - Create a [GitHub PAT](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with **"admin:org" "read:org"** setting enabled on the organization to be used to provision Symphony.
-  - Ensure that [GitHub Cli](https://docs.github.com/en/github-cli/github-cli/about-github-cli) is logged out prior to running the `Symphony pipeline config` cmd.
 
-  for Azure DevOps:
+  For Azure DevOps:
   - Create an [Azure DevOps PAT](https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows) on the organization to be used to provision Symphony.
 
 ## Getting started
@@ -48,7 +47,7 @@ This command deploys following:
 - A set of azure resources and identities required by Symphony for the sample app.
 - Workflows, and resource state management.
 
-It also creates a Symphony.json in ./.symphony/ to store the names of the deployed resources.
+It also creates a symphony.json in ./.symphony/ to store the names of the deployed resources.
 The following resources will be deployed as dependencies for Symphony:
 
 | Resource           | Description                                                                                         | IaC tool|
@@ -67,7 +66,7 @@ The following resources will be deployed as dependencies for Symphony:
 $> symphony destroy
 ```
 
-This command deletes symphony resources that were deployed by executing the `symphony provision` command. It utilizes the Symphony.json file in ./.symphony/ folder.
+This command deletes symphony resources that were deployed by executing the `symphony provision` command. It utilizes the symphony.json file in ./.symphony/ folder.
 
 **Note : Configured Symphony Repository workflow can no longer run after the symphony resources are deleted.**
 

--- a/scripts/install/providers/github/github.sh
+++ b/scripts/install/providers/github/github.sh
@@ -33,14 +33,15 @@ function load_inputs {
         _prompt_input "IS GitHub Repo Private [true;false]" IS_Private_GH_Repo
     fi
 
+    if [ -z "$GH_PAT" ]; then
+        _prompt_input "Enter GitHub PAT" GH_PAT
+    fi
+
     $(gh auth status>/dev/null 2>&1)
     code=$?
     if [ "$code" == "0" ]; then
         _information "GitHub Cli is already logged in. Bootstrap with existing authorization."
     else
-        if [ -z "$GH_PAT" ]; then
-            _prompt_input "Enter GitHub PAT" GH_PAT
-        fi
          echo "$GH_PAT" | gh auth login --with-token
     fi
 }

--- a/scripts/utilities/service_principal.sh
+++ b/scripts/utilities/service_principal.sh
@@ -12,15 +12,17 @@ read_kv_secret() {
 }
 
 function loadServicePrincipalCredentials() {
-    SYMPHONY_KV_NAME=$(get_keyvault_name)
-    if [ "$SYMPHONY_KV_NAME" != "null" ]; then
-        _information "$SYMPHONY_ENV_FILE_PATH Found! Loading needed credentials from ${SYMPHONY_KV_NAME}"
-        SP_SUBSCRIPTION_ID=$(read_kv_secret 'readerSubscriptionId')
-        SP_TENANT_ID=$(read_kv_secret 'readerTenantId')
-        SP_ID=$(read_kv_secret 'readerClientId')
-        SP_SECRET=$(read_kv_secret 'readerClientSecret')
-    fi  
-
+    if [[ -f "$SYMPHONY_ENV_FILE_PATH" ]]; then
+        SYMPHONY_KV_NAME=$(get_keyvault_name)
+        if [ "$SYMPHONY_KV_NAME" != "null" ]; then
+            _information "$SYMPHONY_ENV_FILE_PATH Found! Loading needed credentials from ${SYMPHONY_KV_NAME}"
+            SP_SUBSCRIPTION_ID=$(read_kv_secret 'readerSubscriptionId')
+            SP_TENANT_ID=$(read_kv_secret 'readerTenantId')
+            SP_ID=$(read_kv_secret 'readerClientId')
+            SP_SECRET=$(read_kv_secret 'readerClientSecret')
+        fi  
+    fi
+ 
     if [ -z "$SP_SUBSCRIPTION_ID" ];  then
         _prompt_input "Enter Azure Service Principal Subscription Id" SP_SUBSCRIPTION_ID
     fi
@@ -61,23 +63,27 @@ function printEnvironment() {
 }
 
 function load_symphony_env(){
-    SYMPHONY_KV_NAME=$(get_keyvault_name)
+    if [[ -f "$SYMPHONY_ENV_FILE_PATH" ]]; then
+        SYMPHONY_KV_NAME=$(get_keyvault_name)
+        SYMPHONY_RG_NAME=$(get_json_value "$SYMPHONY_ENV_FILE_PATH" "resource_group")
+        SYMPHONY_ACR_NAME=$(get_json_value "$SYMPHONY_ENV_FILE_PATH" "container_registry")
+        SYMPHONY_SA_STATE_NAME=$(get_json_value "$SYMPHONY_ENV_FILE_PATH" "state_storage_account")
+    fi
+
     if [ -z "$SYMPHONY_KV_NAME" ];  then
         _prompt_input "Enter Symphony KeyVault Name" SYMPHONY_KV_NAME
     fi
-    
-    SYMPHONY_RG_NAME=$(get_json_value "$SYMPHONY_ENV_FILE_PATH" "resource_group")
+
     if [ -z "$SYMPHONY_RG_NAME" ];  then
         _prompt_input "Enter Symphony Resource Group Name" SYMPHONY_RG_NAME
     fi
 
-    SYMPHONY_ACR_NAME=$(get_json_value "$SYMPHONY_ENV_FILE_PATH" "container_registry")
+   
     if [ -z "$SYMPHONY_ACR_NAME" ];  then
         _prompt_input "Enter Symphony Container Registry Name" SYMPHONY_ACR_NAME
     fi
 
     if [ "$IACTOOL" != "bicep" ]; then
-        SYMPHONY_SA_STATE_NAME=$(get_json_value "$SYMPHONY_ENV_FILE_PATH" "state_storage_account")
         if [ -z "$SYMPHONY_SA_STATE_NAME" ];  then
             _prompt_input "Enter Symphony State Storage Account Name" SYMPHONY_SA_STATE_NAME
         fi


### PR DESCRIPTION
This PR resolves #106 and includes the following changes:

- Prompt the user for a GitHub PAT , even if the GH cli is logged in. This is because the PAT is needed for the `git push` and specific scopes are required.
- Fix issue with missing symphony.json , skip reading the file if it does not exist.
- Removed gh logout from getting started docs.