### PR TITLE
Update GH work flows to fail on test failure

### DIFF
--- a/.github/workflows/template.bicep.test.yml
+++ b/.github/workflows/template.bicep.test.yml
@@ -99,5 +99,3 @@ jobs:
           nunit_files: "./IAC/Bicep/test/end_to_end/*.xml"
           check_name: "E2E Tests Results"
           action_fail: true
-          fail_on: "test failures"
-

--- a/.github/workflows/template.terraform.test.yml
+++ b/.github/workflows/template.terraform.test.yml
@@ -92,4 +92,3 @@ jobs:
           files: "./IAC/Terraform/test/terraform/*.xml"
           check_name: "E2E Tests Results"
           action_fail: true
-          fail_on: "test failures"

--- a/.github/workflows/template.terraform.validate.yml
+++ b/.github/workflows/template.terraform.validate.yml
@@ -141,4 +141,3 @@ jobs:
           files: "./IAC/Terraform/test/terraform/*.xml"
           check_name: "Modules tests Results"
           action_fail: true
-          fail_on: "test failures"


### PR DESCRIPTION
This PR  resolves #114  updates the GH workflow publish test results action flags to set the task to fail on the test failure. 

sample passed [CI](https://github.com/hadwagaber/symtest101/actions/runs/4299912723/jobs/7495615161)
sample Failed [CI](https://github.com/hadwagaber/symtest101/actions/runs/4299854308)