### PR TITLE
Adding changes to support intermitent failed acr creation

### DIFF
--- a/scripts/utilities/shell_logger.sh
+++ b/scripts/utilities/shell_logger.sh
@@ -4,6 +4,14 @@ _error() {
     printf " \e[31mError: $@\n\e[0m"
 }
 
+_fail(){
+    step=$1
+    printf "\e[31mFailed $step\n\e[0m"
+    printf "\e[31mError: $2\n\e[0m"
+    printf "\e[31mResources may have been deployed. Please run symphony destroy to clean up orphaned resources.\n\e[0m"
+    exit 1
+}
+
 
 _danger() {
     printf " \e[31m$@\n\e[0m"


### PR DESCRIPTION
This PR introduces a change to the provision process specifically around ACR creation. Rather than wait a fixed amount of time, the script now polls for a status update and then waits at an incremented time. This simple backoff technique ensures that the weight time increases up to a certain maximum and then times out with an error