### PR TITLE
add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax>
+
+/**               @hattan @HadwaAbdelhalem

--- a/scripts/install/contents.sh
+++ b/scripts/install/contents.sh
@@ -9,6 +9,7 @@ function remove_yaml() {
         rm -r "$TARGET_ROOT"/.github/*
     else
         rm -r "$TARGET_ROOT"/.azure-pipelines/*
+        rm "$TARGET_ROOT"/.github/CODEOWNERS
     fi
 }
 function remove_tf_content(){


### PR DESCRIPTION
This PR adds code owners file to be used for pull request reviews. It also updates the provision process to not copy the codeowners file when configuring a new repo 