### PR TITLE
update portal link to support non public cloud

### DIFF
--- a/scripts/install/provision.sh
+++ b/scripts/install/provision.sh
@@ -267,7 +267,10 @@ deploy_dependencies() {
 }
 
 get_resource_group_link(){
-    echo "https://portal.azure.com/#@/resource/subscriptions/$SP_SUBSCRIPTION_ID/resourceGroups/$RG_NAME/overview"
+    cloud_name=$(az cloud show | jq -r '.name')
+    portal_link=$(az cloud show -n "${cloud_name}" | jq -r '.endpoints.portal')
+
+    echo "${portal_link}/#@/resource/subscriptions/$SP_SUBSCRIPTION_ID/resourceGroups/$RG_NAME/overview"
 }
 
 create_rg() {


### PR DESCRIPTION
This PR fixes #159  updates the Symphony provision command to dynamically configure the portal links based on the currently selected cloud type