### PR TITLE
Update Random module provider in 02 Sql

### DIFF
--- a/IAC/Terraform/terraform/02_sql/01_deployment/provider.tf
+++ b/IAC/Terraform/terraform/02_sql/01_deployment/provider.tf
@@ -13,7 +13,10 @@ terraform {
       source  = "aztfmod/azurecaf"
       version = "1.2.15"
     }
-    random = "~> 3.0"
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 


### PR DESCRIPTION
This change updates the provider definition for the random module in the 02Sql/01deployment terraform module. In TFlint 0.47 , using the legacy module version was causing a warning and pipelines were failing as a result.