### PR TITLE
Getting Started Update for Self Hosted Agents

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -24,13 +24,19 @@ Symphony offers a CLI to perform several actions that bootstrap a new IAC projec
     - Create an [Azure DevOps PAT](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops-2022&tabs=Windows) on the organization to be used to provision Symphony.
     - An Agent Pool named `Default` is required for the `symphony pipeline` generated pipelines to run on the target server.  The Default agent pool must include at least one self hosted build agent.
     To deploy a new agent follow the instructions provided in in the [Azure Pipelines - Self-hosted Linux agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/linux-agent?view=azure-devops#download-and-configure-the-agent) walkthrough.
-    Self-hosted agents can be run in a virtual machine or in a [docker container](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops).  When running a build agent container in [Azure Container Instance](https://learn.microsoft.com/en-us/azure/container-instances/), please ensure that the instance size is at least 2 core CPU and 7GB ram. This is required to run symphony pipelines.
+
     - Ensure that the following dependencies are installed on the self hosted agent
 
        ```bash
        sudo apt update
        sudo apt install build-essential unzip
        ```
+
+    - Self-hosted agents can be run in either:
+        - A [docker container](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops).  When running a build agent container in [Azure Container Instance](https://learn.microsoft.com/en-us/azure/container-instances/), please ensure that the instance size is at least 2 core CPU and 7GB ram. This is required to run symphony pipelines.
+
+        - A Linux or Windows VM, see [Getting started with Symphony on a Virtual Machine](./GETTING_STARTED_VM.md)
+
 
 ## Getting started
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -33,10 +33,9 @@ Symphony offers a CLI to perform several actions that bootstrap a new IAC projec
        ```
 
     - Self-hosted agents can be run in either:
-        - A [docker container](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops).  When running a build agent container in [Azure Container Instance](https://learn.microsoft.com/en-us/azure/container-instances/), please ensure that the instance size is at least 2 core CPU and 7GB ram. This is required to run symphony pipelines.
+      - A [docker container](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops).  When running a build agent container in [Azure Container Instance](https://learn.microsoft.com/en-us/azure/container-instances/), please ensure that the instance size is at least 2 core CPU and 7GB ram. This is required to run symphony pipelines.
 
-        - A Linux or Windows VM, see [Getting started with Symphony on a Virtual Machine](./GETTING_STARTED_VM.md)
-
+      - A Linux or Windows VM, see [Getting started with Symphony on a Virtual Machine](./GETTING_STARTED_VM.md)
 
 ## Getting started
 

--- a/docs/GETTING_STARTED_VM.md
+++ b/docs/GETTING_STARTED_VM.md
@@ -1,0 +1,40 @@
+## Agent Configuration
+
+A virtual machine can be either Linux or Windows (with WSL enabled.) It is recommended to run the self-hosted agent as a service, and to run as root.  The agent can be configured as root using the following commands.
+
+```bash
+./config.sh
+sudo ./svc.sh install root
+sudo ./svc.sh start
+```
+
+## Windows (WSL)
+
+If running a self hosted agent on a windows server with WSL. Please complete the following steps.
+```powershell
+# Open a PowerShell window.
+
+# Fetch the DNS Server IP Address. Note the IP address in the result of this command.
+Get-DnsClientServerAddress -InterfaceAlias "Ethernet" -AddressFamily "IPv4"
+
+# Launch WSL
+wsl.exe
+```
+
+```bash
+# Edit or create /etc/wsl.conf
+sudo nano /etc/wsl.conf
+
+# Add the following lines to /etc/wsl.conf
+[network]
+generateResolvConf = false
+
+# Save the file and exit
+# Edit /etc/resolv.conf
+sudo nano /etc/resolv.conf
+
+#Add the following line
+nameserver <ip address of dns obtained from above>
+
+# Save the file and exit
+```

--- a/docs/GETTING_STARTED_VM.md
+++ b/docs/GETTING_STARTED_VM.md
@@ -1,3 +1,5 @@
+# Getting Started with Symphony and self hosted build agents on a Virtual Machine
+
 ## Agent Configuration
 
 A virtual machine can be either Linux or Windows (with WSL enabled.) It is recommended to run the self-hosted agent as a service, and to run as root.  The agent can be configured as root using the following commands.
@@ -11,6 +13,7 @@ sudo ./svc.sh start
 ## Windows (WSL)
 
 If running a self hosted agent on a windows server with WSL. Please complete the following steps.
+
 ```powershell
 # Open a PowerShell window.
 


### PR DESCRIPTION
The following PR introduces documentation changes to Getting Started a new Getting Started on VM document that outlines steps needed to:
- Run the Self Hosted Agent as a Server in Linux.
- Configure WSL to use host machines DNS server.

Co-authored-by: Hadwa Gaber <hadwaa@microsoft.com>