### PR TITLE
Updating to show the error of tlint

### DIFF
--- a/scripts/orchestrators/iac.tf.sh
+++ b/scripts/orchestrators/iac.tf.sh
@@ -128,7 +128,7 @@ lint() {
 
     # We will disable "exit on error" to avoid tflint breaking our execution
     set +e
-    output=$(tflint >"$filePath" 2>&1); local code=$?
+    tflint >"$filePath" 2>&1; local code=$?
     set -e
 
     if [[ -z $(grep '[^[:space:]]' $filePath) ]]; then

--- a/scripts/orchestrators/iac.tf.sh
+++ b/scripts/orchestrators/iac.tf.sh
@@ -126,16 +126,18 @@ lint() {
     lint_res_file_name="$(basename $PWD)_lint_res.xml"
     filePath=$(echo "${lint_res_file_name}" | sed -e 's/\//-/g')
 
-    "tflint" >$filePath 2>&1
+    # We will disable "exit on error" to avoid tflint breaking our execution
+    set +e
+    output=$(tflint >"$filePath" 2>&1); local code=$?
+    set -e
 
-    local code=$?
     if [[ -z $(grep '[^[:space:]]' $filePath) ]]; then
         echo "tflint passed"
         #exit 0
     else
         echo "tflint failed. lint results in file name ${lint_res_file_name}"
         sed -i 's/\x1b\[[0-9;]*m//g' $filePath
-        cat $filePath
+        _error $(<"$filePath")
         #exit 1
     fi
     return $code


### PR DESCRIPTION
Fixes #203  for tflint

The problem is that the scripts contains `set -e` at the beginning, and as soon as tflint fails it breaks the execution. Discussed offline the options to solve the problem, and confirmed that an explicit disable/enable of erronexit would be beneficial to maintainability and code-readability.

Confirmed it works in local:

![image](https://github.com/microsoft/symphony/assets/952392/b3974ac2-7487-4b4c-bc26-68c7ea62dfa9)

and in Azure DevOps:

![image](https://github.com/microsoft/symphony/assets/952392/3c936ae8-e134-4802-87b8-c1c91d72457e)

Pending to be verified in GitHub before merge.