### PR TITLE
Adding lint res xml files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ arm-ttk/
 .actrc
 .symphony
 .vscode
+IAC/**/*lint_res.xml


### PR DESCRIPTION
When testing/using tflint locally it generates the following files: 

![image](https://github.com/microsoft/symphony/assets/952392/6e1abc9d-84a6-4481-b7af-62179ee71cf1)

these files could also conflict with the ones generated by the pipeline, to avoid local results to be pushed to the repo invertedly we could add any file under IAC and subdirectories that ends with _lint_res.xml to the .gitignore 