### PR TITLE
Update setup-armttk.sh

### DIFF
--- a/scripts/orchestrators/setup-armttk.sh
+++ b/scripts/orchestrators/setup-armttk.sh
@@ -13,7 +13,7 @@ source _helpers.sh
 source _setup_helpers.sh
 
 set -e
-VERSION="${1:-"latest"}"
+VERSION="${1:-"20221215"}"
 
 # Verify requested version is available, convert latest
 find_version_from_git_tags VERSION 'https://github.com/Azure/arm-ttk' 'tags/' 'none'


### PR DESCRIPTION
Update Arm-ttk default version to 2022.12.15 instead of latest. latest version on armtttk changed the binary structure that cause the path to fail.

AZDO Bicep [CI](https://dev.azure.com/csedevops/Symphony/_build/results?buildId=15434&view=logs&j=92058b04-f16a-5035-546c-cae3ad5e2f5f&t=92058b04-f16a-5035-546c-cae3ad5e2f5f)