### PR TITLE
AzDo Devx small improvements

### DIFF
--- a/scripts/install/cli/symphony
+++ b/scripts/install/cli/symphony
@@ -173,6 +173,7 @@ configure_orchestrator() {
         git commit -m "Update resource names"
         push_repo
 
+        _information "Performing final validations"
         check_error_log
     popd || exit
 }

--- a/scripts/utilities/shell_inputs.sh
+++ b/scripts/utilities/shell_inputs.sh
@@ -120,6 +120,7 @@ function _prompt_input {
     input_description=${1}
     input_name=${2}
     is_danger=${3}
+    is_secret=${4}
 
     echo ""
     if [[ "$is_danger" == "true" ]]; then
@@ -128,7 +129,13 @@ function _prompt_input {
       echo -n "> $input_description : "
     fi
 
-    read $input_name
+    if [[ "$is_secret" == "true" ]]; then
+      read -s $input_name
+      echo -n "***"
+      echo
+    else
+      read $input_name
+    fi
 }
 
 function _validate_inputs {


### PR DESCRIPTION
While working in #203 I was finding small improvements in the usability experience of symphony while provisioning AzDo. The ones implemented in this PR are:

* When provisioning AzDo, at the end there is a check for error_log which if founds an issue throws an error, however it was not clear what step failed. Discovered it was a sanity check, so added a message consistent with it.

Example:

![image](https://github.com/microsoft/symphony/assets/952392/f74a24e3-3128-4db6-b9fc-808325719ee9)

* Adding an option to _prompt_input to receive secrets, by hiding the value and adding some stars.  This is used when asking for the AzDo PAT to avoid showing the secret on screen:

![image](https://github.com/microsoft/symphony/assets/952392/c037e9e9-33f7-46ba-9595-e7919ed9b00d)

* When a PaaS URL for AzDO is provided in the form of https://dev.azure.com/ORGANIZATION the organization can be taken from the first step, avoiding asking for repetitive information that could also cause an issue if a typo is provided. Example:

![image](https://github.com/microsoft/symphony/assets/952392/bbd2cb0d-6a4a-4e36-ac5b-e96cb647853e)
