### PR TITLE
Fix an issue with the deletion of RGs and Deployments based on tags

### DIFF
--- a/scripts/orchestrators/iac.bicep.sh
+++ b/scripts/orchestrators/iac.bicep.sh
@@ -255,8 +255,17 @@ destroy() {
                 _error "Deleting deployment : ${deployment} failed"
                 return ${exit_code}
             fi
+
+            deploymentNameGenerator="${deployment}NameGenerator"
+            _information "Deleting deployment : ${deploymentNameGenerator}"
+            az deployment sub delete --name "${deploymentNameGenerator}"
+            exit_code=$?
+            if [[ ${exit_code} != 0 ]]; then
+                _error "Deleting deployment : ${deploymentNameGenerator} failed"
+                return ${exit_code}
+            fi
         done
-       
+
         _information "Destroying resource group: ${resourceGroup}"
         az group delete --resource-group "${resourceGroup}" --yes
         exit_code=$?

--- a/scripts/orchestrators/iac.bicep.sh
+++ b/scripts/orchestrators/iac.bicep.sh
@@ -208,7 +208,21 @@ destroy() {
     local layerName=${2}
     local location=${3}
 
-    deployments=$(az deployment sub list --query "[?tag=='GeneratedBy=symphony']" --query "[?tag=='EnvironmentName=${environmentName}']" --query "[?tag=='LayerName=${layerName}']" --query "[?location=='${location}']" --output json |jq -c -r '.[].name')
+    #deployments=$(az deployment sub list 
+    #--query "[?tag=='GeneratedBy=symphony']" 
+    #--query "[?tag=='EnvironmentName=${environmentName}']" 
+    #--query "[?tag=='LayerName=${layerName}']" 
+    #--query "[?location=='${location}']" 
+    #--output json |jq -c -r '.[].name')
+    deployments=$(az deployment sub list --output json | \
+        jq -c -r ".[]
+            | select(
+                .location == \"${location}\" and
+                .tags.GeneratedBy == \"symphony\" and
+                .tags.EnvironmentName == \"${environmentName}\" and
+                .tags.LayerName == \"${layerName}\")
+            | .name")
+    
     exit_code=$?
 
     for deployment in ${deployments}; do
@@ -221,7 +235,20 @@ destroy() {
         fi
     done
 
-    resourceGroups=$(az group list --tag "GeneratedBy=symphony" --tag "EnvironmentName=${environmentName}" --tag "LayerName=${layerName}" --query "[?location=='${location}']" --output json |jq -c -r '.[].name')
+    #resourceGroups=$(az group list 
+    #--tag "GeneratedBy=symphony" 
+    #--tag "EnvironmentName=${environmentName}" 
+    #--tag "LayerName=${layerName}" 
+    #--query "[?location=='${location}']" --output json |jq -c -r '.[].name')
+    resourceGroups=$(az group list --output json | \
+        jq -c -r ".[]
+            | select(
+                .location == \"${location}\" and
+                .tags.GeneratedBy == \"symphony\" and
+                .tags.EnvironmentName == \"${environmentName}\" and
+                .tags.LayerName == \"${layerName}\")
+            | .name")
+
     for resourceGroup in ${resourceGroups}; do
         _information "Destroying resource group: ${resourceGroup}"
         az group delete --resource-group "${resourceGroup}" --yes

--- a/scripts/orchestrators/iac.bicep.sh
+++ b/scripts/orchestrators/iac.bicep.sh
@@ -218,6 +218,12 @@ destroy() {
                 .tags.LayerName == \"${layerName}\")
             | @base64")
 
+    exit_code=$?
+    if [[ ${exit_code} != 0 ]]; then
+        _error "Getting resource groups failed"
+        return ${exit_code}
+    fi
+
     _information "For each resource groups..."
     for b64ResourceGroup in ${resourceGroups}; do
         resourceGroupJson=$(echo "$b64ResourceGroup" | base64 --decode)
@@ -230,6 +236,12 @@ destroy() {
                 | select(
                     .properties.outputResources[]? | select(.id == \"${resourceGroupId}\"))
                 | @base64")
+
+        exit_code=$?
+        if [[ ${exit_code} != 0 ]]; then
+            _error "Getting deployments for ${resourceGroup} failed"
+            return ${exit_code}
+        fi
         
         _information "For each deployment..."
         for b64Deployment in ${deployments}; do


### PR DESCRIPTION
This PR changes the way the RGs and deployments are queried when deleting an environment.

It used to be based on `--tag` or `--query` in the `az` cli, but it seems that the behavior changed recently.