### PR TITLE
Force Name field in Azure Table to be Edm.String

### DIFF
--- a/.github/workflows/workflow.pr.terraform.yml
+++ b/.github/workflows/workflow.pr.terraform.yml
@@ -82,7 +82,7 @@ jobs:
       pipelineName: PR
       eventName: NewEnvironment
       eventGroupId: PR-${{ github.event.pull_request.number }}-${{ github.repository_id }}
-      data: Name=${{ needs.Setup.outputs.environmentName }} SHA=${{ github.event.pull_request.head.sha }} Directory=${{ needs.Setup.outputs.prEnvironmentDirectory }}
+      data: Name=${{ needs.Setup.outputs.environmentName }} SHA=${{ github.event.pull_request.head.sha }} Directory=${{ needs.Setup.outputs.prEnvironmentDirectory }} Name@odata.type=Edm.String
       keyVaultName: ${{ needs.Setup.outputs.keyVaultName }}
       comment: |
         Creating environment with name: "${{ needs.Setup.outputs.environmentName }}" using commit: "${{ github.event.pull_request.head.sha }}".


### PR DESCRIPTION
This forces the Name to be Edm.String, when adding events. If by chance, the name started with a number, it would add an invalid value to the table.