### PR TITLE
Fix pipeline create templates

### DIFF
--- a/scripts/install/providers/azdo/templates/pipeline-authorize.json
+++ b/scripts/install/providers/azdo/templates/pipeline-authorize.json
@@ -1,7 +1,7 @@
 {
   "pipelines": [
     {
-      "id": "__PIPELINE_ID__",
+      "id": __PIPELINE_ID__,
       "authorized": true
     }
   ]

--- a/scripts/install/providers/azdo/templates/pipeline-create.json
+++ b/scripts/install/providers/azdo/templates/pipeline-create.json
@@ -21,20 +21,23 @@
       "pollingJobId": null,
       "pollingInterval": 0,
       "pathFilters": [],
-      "branchFilters": ["+refs/heads/main"],
+      "branchFilters": [
+        "+refs/heads/main"
+      ],
       "defaultSettingsSourceType": 2,
       "isSettingsSourceOptionSupported": true,
       "settingsSourceType": 2,
       "triggerType": 2
     }
   ],
-  "variables": ["__ADO_PIPELINE_VARIABLES__"],
+  "variables": { __ADO_PIPELINE_VARIABLES__
+  },
   "queue": {
-    "id": "__ADO_POOL_ID__",
+    "id": __ADO_POOL_ID__,
     "name": "__ADO_POOL_NAME__",
     "url": "__AZDO_ORG_URI__/_apis/build/Queues/__ADO_POOL_ID__",
     "pool": {
-      "id": "__ADO_POOL_ID__",
+      "id": __ADO_POOL_ID__,
       "name": "__ADO_POOL_NAME__",
       "isHosted": true
     }

--- a/scripts/install/providers/azdo/templates/pipeline-variable.json
+++ b/scripts/install/providers/azdo/templates/pipeline-variable.json
@@ -1,7 +1,5 @@
-{
-  "__PIPELINE_VAR_NAME__": {
-    "value": "__PIPELINE_VAR_VALUE__",
-    "isSecret": "__PIPELINE_VAR_IS_SECRET__",
-    "allowOverride": "__PIPELINE_ALLOW_OVERRIDE__"
-  }
+"__PIPELINE_VAR_NAME__": {
+  "value": "__PIPELINE_VAR_VALUE__",
+  "isSecret": __PIPELINE_VAR_IS_SECRET__,
+  "allowOverride": __PIPELINE_ALLOW_OVERRIDE__
 }


### PR DESCRIPTION
This PR fixes a bug when running Symphony CLI cmd: symphony pipeline config for Azure devops where pipelines were creating without the expected variables.

 I tested the changes and where able to successfully configure an azure devops repo for terraform and run the Deploy pipeline.

