### PR TITLE
Update minimum Terraform version to 1.11.0 to support az cli auth

### DIFF
--- a/.azure-pipelines/pipeline.ci.terraform.yml
+++ b/.azure-pipelines/pipeline.ci.terraform.yml
@@ -30,7 +30,7 @@ variables:
 
   # Terraform version
   # - name: terraformVersion
-  #   value: "1.6.2"
+  #   value: "1.11.0-beta2"
   # Run Layer tests
   - name: layerTestEnabled
     value: $(runLayerTest)

--- a/.azure-pipelines/template.terraform.destroy.yml
+++ b/.azure-pipelines/template.terraform.destroy.yml
@@ -26,6 +26,5 @@ jobs:
             export STATE_STORAGE_ACCOUNT="$(stateStorageAccount)"
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.destroy.sh

--- a/.azure-pipelines/template.terraform.previewdeploy.yml
+++ b/.azure-pipelines/template.terraform.previewdeploy.yml
@@ -45,6 +45,5 @@ jobs:
             export STATE_STORAGE_ACCOUNT="$(stateStorageAccount)"
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.previewdeploy.sh

--- a/.azure-pipelines/template.terraform.report.yml
+++ b/.azure-pipelines/template.terraform.report.yml
@@ -27,6 +27,5 @@ jobs:
             export STATE_STORAGE_ACCOUNT_BACKUP="$(stateStorageAccountBackup)"
             export COMMIT_ID="$(Build.SourceVersion)"
             export RUN_ID="$(Build.BuildId)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.statebackup.sh

--- a/.azure-pipelines/template.terraform.test.yml
+++ b/.azure-pipelines/template.terraform.test.yml
@@ -46,7 +46,6 @@ jobs:
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
             export TEST_TAG=""
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.test.sh
 

--- a/.azure-pipelines/template.terraform.validate.yml
+++ b/.azure-pipelines/template.terraform.validate.yml
@@ -71,7 +71,6 @@ jobs:
             export STATE_STORAGE_ACCOUNT="$(stateStorageAccount)"
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.validate.sh
 
@@ -91,7 +90,6 @@ jobs:
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
             export TEST_TAG="module_tests"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.test.sh
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "args": {
       "VARIANT": "bullseye",
-      "TERRAFORM_VERSION": "1.6.2",
+      "TERRAFORM_VERSION": "1.11.0-beta2",
       "TFLINT_VERSION": "0.34.1",
       "TFLINT_RULESET_AZURERM_VERSION": "v0.14.0",
       "TERRAGRUNT_VERSION": "0.36.3",
@@ -88,7 +88,7 @@
     "docker-in-docker": "latest",
     "docker-from-docker": "latest",
     // "terraform": {
-    // 	"version": "1.6.2",
+    // 	"version": "1.11.0-beta2",
     // 	"tflint": "0.34.1",
     // 	"terragrunt": "0.36.3"
     // },

--- a/.github/workflows/workflow.ci.terraform.yml
+++ b/.github/workflows/workflow.ci.terraform.yml
@@ -23,7 +23,7 @@ on: # yamllint disable-line rule:truthy
       terraformVersion:
         description: "Terraform version"
         required: true
-        default: "1.6.2"
+        default: "1.11.0-beta2"
       runLayerTest:
         description: "Run Layers Tests"
         type: boolean

--- a/.github/workflows/workflow.cleanup.terraform.yml
+++ b/.github/workflows/workflow.cleanup.terraform.yml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
       terraformVersion:
         type: string
         required: true
-        default: "1.6.2"
+        default: "1.11.0-beta2"
 
 permissions:
   id-token: write

--- a/.github/workflows/workflow.destroy.terraform.yml
+++ b/.github/workflows/workflow.destroy.terraform.yml
@@ -14,7 +14,7 @@ on: # yamllint disable-line rule:truthy
       terraformVersion:
         description: "Terraform version"
         required: true
-        default: "1.6.2"
+        default: "1.11.0-beta2"
 
 permissions:
   id-token: write

--- a/.github/workflows/workflow.pr.terraform.cleanup.yml
+++ b/.github/workflows/workflow.pr.terraform.cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
   group: pr-${{ github.event.pull_request.number }}
 
 env:
-  TERRAFORM_VERSION: "1.6.2"
+  TERRAFORM_VERSION: "1.11.0-beta2"
 
 permissions:
   id-token: write

--- a/.github/workflows/workflow.pr.terraform.yml
+++ b/.github/workflows/workflow.pr.terraform.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   PR_ENVIRONMENT_DIRECTORY: "pr"
-  TERRAFORM_VERSION: "1.6.2"
+  TERRAFORM_VERSION: "1.11.0-beta2"
   RUN_LAYER_TESTS: false
 
 permissions:

--- a/IAC/Terraform/terraform/01_init/provider.tf
+++ b/IAC/Terraform/terraform/01_init/provider.tf
@@ -4,7 +4,7 @@ initialize the Azure environment. No remote storage, only performed once.
 
 #Set the terraform required version, and Configure the Azure Provider
 terraform {
-  required_version = ">= 1.6.2, < 2.0.0"
+  required_version = ">= 1.11.0, < 2.0.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/IAC/Terraform/terraform/02_storage/01_deployment/provider.tf
+++ b/IAC/Terraform/terraform/02_storage/01_deployment/provider.tf
@@ -2,7 +2,7 @@
 
 # Configure the Azure Provider
 terraform {
-  required_version = ">= 1.6.2, < 2.0.0"
+  required_version = ">= 1.11.0, < 2.0.0"
   backend "azurerm" {}
   required_providers {
     azurerm = {

--- a/IAC/Terraform/terraform/03_config/01_deployment/provider.tf
+++ b/IAC/Terraform/terraform/03_config/01_deployment/provider.tf
@@ -2,7 +2,7 @@
 
 # Configure the Azure Provider
 terraform {
-  required_version = ">= 1.6.2, < 2.0.0"
+  required_version = ">= 1.11.0, < 2.0.0"
   backend "azurerm" {}
   required_providers {
     azurerm = {

--- a/docs/DEVELOPER_EXPERIENCE.md
+++ b/docs/DEVELOPER_EXPERIENCE.md
@@ -11,7 +11,7 @@ The [DevContainer configuration](./../.devcontainer/devcontainer.json) uses a [D
 The _DevContainer_ is based on the _Ubuntu:bullseye_ image and has the following packages installed:
 
 - [golang 1.17.8](https://go.dev/)
-- [Terraform 1.6.2](https://www.terraform.io/)
+- [Terraform 1.11.0-beta2](https://www.terraform.io/)
 - [TFLint 0.34.1](https://github.com/terraform-linters/tflint)
 - [TFLint Ruleset for terraform-provider-azurerm 0.14.0](https://github.com/terraform-linters/tflint-ruleset-azurerm)
 - [Terragrunt 0.36.3](https://terragrunt.gruntwork.io/)

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -156,7 +156,7 @@ function create_pipelines_terraform() {
   pipelineVariables=$(_get_pipeline_var_defintion environmentName dev true)
 
   pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion goVersion 1.18.1 true)"
-  pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion terraformVersion 1.6.2 true)"
+  pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion terraformVersion 1.11.0-beta2 true)"
   pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion runLayerTest false true)"
   pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion runBackupState true true)"
   _create_pipeline "CI-Deploy" "/.azure-pipelines/pipeline.ci.terraform.yml" "Deploy" "${pipelineVariables}" "${AZDO_PROJECT_NAME}"

--- a/scripts/orchestrators/_setup_helpers.sh
+++ b/scripts/orchestrators/_setup_helpers.sh
@@ -41,7 +41,7 @@ find_version_from_git_tags() {
     else
       last_part="${escaped_separator}[0-9]+"
     fi
-    local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+    local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}(-[A-Za-z0-9]+)*$"
     local version_list="$(git ls-remote --tags "${repository}" | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
     if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
       declare -g "${variable_name}"="$(echo "${version_list}" | head -n 1)"

--- a/scripts/orchestrators/iac.tf.sh
+++ b/scripts/orchestrators/iac.tf.sh
@@ -18,14 +18,9 @@ usage() {
 set_arm_env_vars() {
   # retrieve client_id, subscription_id, tenant_id from logged in user
   azaccount=$(az account show)
-  client_id=$(echo $azaccount | jq -r .user.name)
   subscription_id=$(echo $azaccount | jq -r .id)
-  tenant_id=$(echo $azaccount | jq -r .tenantId)
 
   export ARM_SUBSCRIPTION_ID=$subscription_id
-  export ARM_CLIENT_ID=$client_id
-  export ARM_TENANT_ID=$tenant_id
-  export ARM_USE_OIDC=true
   export ARM_STORAGE_USE_AZUREAD=true
 }
 
@@ -50,9 +45,6 @@ init() {
             -backend-config=key=${key} \
             -backend-config=resource_group_name=${resource_group_name} \
             -backend-config=subscription_id=${ARM_SUBSCRIPTION_ID} \
-            -backend-config=tenant_id=${ARM_TENANT_ID} \
-            -backend-config=client_id=${ARM_CLIENT_ID} \
-            -backend-config=use_oidc=true \
             -backend-config=use_azuread_auth=true \
             -reconfigure"
 
@@ -62,9 +54,6 @@ init() {
       -backend-config=key=${key} \
       -backend-config=resource_group_name=${resource_group_name} \
       -backend-config=subscription_id=${ARM_SUBSCRIPTION_ID} \
-      -backend-config=tenant_id=${ARM_TENANT_ID} \
-      -backend-config=client_id=${ARM_CLIENT_ID} \
-      -backend-config=use_oidc=true \
       -backend-config=use_azuread_auth=true \
       -reconfigure
   fi

--- a/scripts/orchestrators/iac.tf.test.sh
+++ b/scripts/orchestrators/iac.tf.test.sh
@@ -14,14 +14,9 @@ export container_name="${STATE_CONTAINER}"
 
 # retrieve client_id, subscription_id, tenant_id from logged in user
 azaccount=$(az account show)
-client_id=$(echo $azaccount | jq -r .user.name)
 subscription_id=$(echo $azaccount | jq -r .id)
-tenant_id=$(echo $azaccount | jq -r .tenantId)
 
 export ARM_SUBSCRIPTION_ID=$subscription_id
-export ARM_CLIENT_ID=$client_id
-export ARM_TENANT_ID=$tenant_id
-export ARM_USE_OIDC=true
 export ARM_USE_AZUREAD=true
 
 if [[ "${TEST_TAG}" == "module_tests" ]]; then


### PR DESCRIPTION
This PR updates the minimum Terraform version to 1.11.0 to support az cli auth.

This also simplifies the login operation for the azurerm backend by removing the need of specific variables set for it, since now it can fully rely on the az cli login