### PR TITLE
Add sudo to move commands in setup scripts for proper permissions

### DIFF
--- a/scripts/orchestrators/setup-age.sh
+++ b/scripts/orchestrators/setup-age.sh
@@ -27,6 +27,6 @@ filename="age-v${VERSION}-linux-${os_architecture}.tar.gz"
 curl -sSL -o "${filename}" "https://github.com/FiloSottile/age/releases/download/v${VERSION}/${filename}"
 tar -xf "${filename}" age
 rm -f "${filename}"
-mv -f age/age /usr/local/bin/
-mv -f age/age-keygen /usr/local/bin/
+sudo mv -f age/age /usr/local/bin/
+sudo mv -f age/age-keygen /usr/local/bin/
 rm -rf age

--- a/scripts/orchestrators/setup-gitleaks.sh
+++ b/scripts/orchestrators/setup-gitleaks.sh
@@ -27,4 +27,4 @@ filename="gitleaks_${VERSION}_linux_${os_architecture}.tar.gz"
 curl -sSL -o "${filename}" "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/${filename}"
 tar -xf "${filename}" gitleaks
 rm -f "${filename}"
-mv -f gitleaks /usr/local/bin/
+sudo mv -f gitleaks /usr/local/bin/

--- a/scripts/orchestrators/setup-powershell.sh
+++ b/scripts/orchestrators/setup-powershell.sh
@@ -29,5 +29,5 @@ mkdir -p tmp/pwsh "${target_path}"
 cd tmp/pwsh
 curl -sSL -o "${filename}" "https://github.com/PowerShell/PowerShell/releases/download/v${VERSION}/${filename}"
 tar -xf "${filename}" -C "${target_path}"
-ln -s "${target_path}/pwsh" /usr/local/bin/pwsh
+sudo ln -s "${target_path}/pwsh" /usr/local/bin/pwsh
 rm -rf tmp/pwsh

--- a/scripts/orchestrators/setup-sops.sh
+++ b/scripts/orchestrators/setup-sops.sh
@@ -26,4 +26,4 @@ _information "Downloading SOPS..."
 filename="sops-v${VERSION}.linux.${os_architecture}"
 echo "${filename}"
 curl -sSL -o "${filename}" "https://github.com/mozilla/sops/releases/download/v${VERSION}/${filename}"
-mv -f "${filename}" /usr/local/bin/sops
+sudo mv -f "${filename}" /usr/local/bin/sops

--- a/scripts/orchestrators/setup-terraform.sh
+++ b/scripts/orchestrators/setup-terraform.sh
@@ -22,4 +22,4 @@ curl -sSL -o "${filename}" "https://releases.hashicorp.com/terraform/${VERSION}/
 unzip "${filename}"
 rm -f "${filename}"
 # ln -s "terraform" /usr/local/bin/terraform
-mv -f terraform /usr/local/bin/
+sudo mv -f terraform /usr/local/bin/

--- a/scripts/orchestrators/setup-tflint.sh
+++ b/scripts/orchestrators/setup-tflint.sh
@@ -27,4 +27,4 @@ filename="tflint_linux_${os_architecture}.zip"
 curl -sSL -o "${filename}" "https://github.com/terraform-linters/tflint/releases/download/v${VERSION}/${filename}"
 unzip "${filename}"
 rm -f "${filename}"
-mv -f tflint /usr/local/bin/
+sudo mv -f tflint /usr/local/bin/


### PR DESCRIPTION
When installing some of the tools used by the pipeline, the setup scripts need to move the downloaded files to the appropriate directories.

Without `sudo`, some of those commands were failing on private runners.

This PR fixes that