### PR TITLE
Private runners creation support, tooling setup improvement and TF pipeline simplifications, removal of PAT requirements

### DIFF
--- a/.azure-pipelines/pipeline.ci.terraform.yml
+++ b/.azure-pipelines/pipeline.ci.terraform.yml
@@ -30,7 +30,7 @@ variables:
 
   # Terraform version
   # - name: terraformVersion
-  #   value: "1.6.2"
+  #   value: "1.11.0"
   # Run Layer tests
   - name: layerTestEnabled
     value: $(runLayerTest)

--- a/.azure-pipelines/template.bicep.test.yml
+++ b/.azure-pipelines/template.bicep.test.yml
@@ -26,9 +26,10 @@ jobs:
         inputs:
           workingDirectory: "$(System.DefaultWorkingDirectory)/scripts/orchestrators"
           bashEnvValue: "~/.profile"
-          failOnStderr: true
+          failOnStderr: false
           targetType: "inline"
           script: |
+            set -e
             ./setup-azcli.sh
             ./setup-powershell.sh
             ./setup-pester.sh

--- a/.azure-pipelines/template.bicep.validate.yml
+++ b/.azure-pipelines/template.bicep.validate.yml
@@ -19,9 +19,10 @@ jobs:
         inputs:
           workingDirectory: "$(System.DefaultWorkingDirectory)/scripts/orchestrators"
           bashEnvValue: "~/.profile"
-          failOnStderr: true
+          failOnStderr: false
           targetType: "inline"
           script: |
+            set -e
             ./setup-azcli.sh
             ./setup-gitleaks.sh
             ./setup-powershell.sh

--- a/.azure-pipelines/template.terraform.destroy.yml
+++ b/.azure-pipelines/template.terraform.destroy.yml
@@ -26,6 +26,5 @@ jobs:
             export STATE_STORAGE_ACCOUNT="$(stateStorageAccount)"
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.destroy.sh

--- a/.azure-pipelines/template.terraform.previewdeploy.yml
+++ b/.azure-pipelines/template.terraform.previewdeploy.yml
@@ -45,6 +45,5 @@ jobs:
             export STATE_STORAGE_ACCOUNT="$(stateStorageAccount)"
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.previewdeploy.sh

--- a/.azure-pipelines/template.terraform.report.yml
+++ b/.azure-pipelines/template.terraform.report.yml
@@ -27,6 +27,5 @@ jobs:
             export STATE_STORAGE_ACCOUNT_BACKUP="$(stateStorageAccountBackup)"
             export COMMIT_ID="$(Build.SourceVersion)"
             export RUN_ID="$(Build.BuildId)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.statebackup.sh

--- a/.azure-pipelines/template.terraform.test.yml
+++ b/.azure-pipelines/template.terraform.test.yml
@@ -46,7 +46,6 @@ jobs:
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
             export TEST_TAG=""
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.test.sh
 

--- a/.azure-pipelines/template.terraform.validate.yml
+++ b/.azure-pipelines/template.terraform.validate.yml
@@ -19,9 +19,10 @@ jobs:
           workingDirectory: "$(System.DefaultWorkingDirectory)/scripts/orchestrators"
           arguments: ${{ parameters.terraformVersion }}
           bashEnvValue: "~/.profile"
-          failOnStderr: true
+          failOnStderr: false
           targetType: "inline"
           script: |
+            set -e
             ./setup-azcli.sh
             ./setup-terraform.sh ${{ parameters.terraformVersion }}
             ./setup-tflint.sh

--- a/.azure-pipelines/template.terraform.validate.yml
+++ b/.azure-pipelines/template.terraform.validate.yml
@@ -72,7 +72,6 @@ jobs:
             export STATE_STORAGE_ACCOUNT="$(stateStorageAccount)"
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.validate.sh
 
@@ -92,7 +91,6 @@ jobs:
             export STATE_CONTAINER="$(stateContainer)"
             export ENVIRONMENT_NAME="$(environmentName)"
             export TEST_TAG="module_tests"
-            export ARM_OIDC_TOKEN="$idToken"
 
             ./iac.tf.test.sh
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "args": {
       "VARIANT": "bullseye",
-      "TERRAFORM_VERSION": "1.6.2",
+      "TERRAFORM_VERSION": "1.11.0",
       "TFLINT_VERSION": "0.34.1",
       "TFLINT_RULESET_AZURERM_VERSION": "v0.14.0",
       "TERRAGRUNT_VERSION": "0.36.3",
@@ -88,7 +88,7 @@
     "docker-in-docker": "latest",
     "docker-from-docker": "latest",
     // "terraform": {
-    // 	"version": "1.6.2",
+    // 	"version": "1.11.0",
     // 	"tflint": "0.34.1",
     // 	"terragrunt": "0.36.3"
     // },

--- a/.github/workflows/workflow.ci.terraform.yml
+++ b/.github/workflows/workflow.ci.terraform.yml
@@ -23,7 +23,7 @@ on: # yamllint disable-line rule:truthy
       terraformVersion:
         description: "Terraform version"
         required: true
-        default: "1.6.2"
+        default: "1.11.0"
       runLayerTest:
         description: "Run Layers Tests"
         type: boolean

--- a/.github/workflows/workflow.cleanup.terraform.yml
+++ b/.github/workflows/workflow.cleanup.terraform.yml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
       terraformVersion:
         type: string
         required: true
-        default: "1.6.2"
+        default: "1.11.0"
 
 permissions:
   id-token: write

--- a/.github/workflows/workflow.destroy.terraform.yml
+++ b/.github/workflows/workflow.destroy.terraform.yml
@@ -14,7 +14,7 @@ on: # yamllint disable-line rule:truthy
       terraformVersion:
         description: "Terraform version"
         required: true
-        default: "1.6.2"
+        default: "1.11.0"
 
 permissions:
   id-token: write

--- a/.github/workflows/workflow.pr.terraform.cleanup.yml
+++ b/.github/workflows/workflow.pr.terraform.cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
   group: pr-${{ github.event.pull_request.number }}
 
 env:
-  TERRAFORM_VERSION: "1.6.2"
+  TERRAFORM_VERSION: "1.11.0"
 
 permissions:
   id-token: write

--- a/.github/workflows/workflow.pr.terraform.yml
+++ b/.github/workflows/workflow.pr.terraform.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   PR_ENVIRONMENT_DIRECTORY: "pr"
-  TERRAFORM_VERSION: "1.6.2"
+  TERRAFORM_VERSION: "1.11.0"
   RUN_LAYER_TESTS: false
 
 permissions:

--- a/IAC/Terraform/terraform/01_init/provider.tf
+++ b/IAC/Terraform/terraform/01_init/provider.tf
@@ -4,7 +4,7 @@ initialize the Azure environment. No remote storage, only performed once.
 
 #Set the terraform required version, and Configure the Azure Provider
 terraform {
-  required_version = ">= 1.6.2, < 2.0.0"
+  required_version = ">= 1.11.0, < 2.0.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/IAC/Terraform/terraform/02_storage/01_deployment/provider.tf
+++ b/IAC/Terraform/terraform/02_storage/01_deployment/provider.tf
@@ -2,7 +2,7 @@
 
 # Configure the Azure Provider
 terraform {
-  required_version = ">= 1.6.2, < 2.0.0"
+  required_version = ">= 1.11.0, < 2.0.0"
   backend "azurerm" {}
   required_providers {
     azurerm = {

--- a/IAC/Terraform/terraform/03_config/01_deployment/provider.tf
+++ b/IAC/Terraform/terraform/03_config/01_deployment/provider.tf
@@ -2,7 +2,7 @@
 
 # Configure the Azure Provider
 terraform {
-  required_version = ">= 1.6.2, < 2.0.0"
+  required_version = ">= 1.11.0, < 2.0.0"
   backend "azurerm" {}
   required_providers {
     azurerm = {

--- a/docs/DEVELOPER_EXPERIENCE.md
+++ b/docs/DEVELOPER_EXPERIENCE.md
@@ -11,7 +11,7 @@ The [DevContainer configuration](./../.devcontainer/devcontainer.json) uses a [D
 The _DevContainer_ is based on the _Ubuntu:bullseye_ image and has the following packages installed:
 
 - [golang 1.17.8](https://go.dev/)
-- [Terraform 1.6.2](https://www.terraform.io/)
+- [Terraform 1.11.0](https://www.terraform.io/)
 - [TFLint 0.34.1](https://github.com/terraform-linters/tflint)
 - [TFLint Ruleset for terraform-provider-azurerm 0.14.0](https://github.com/terraform-linters/tflint-ruleset-azurerm)
 - [Terragrunt 0.36.3](https://terragrunt.gruntwork.io/)

--- a/scripts/install/cli/symphony
+++ b/scripts/install/cli/symphony
@@ -125,7 +125,6 @@ configure_orchestrator() {
   if [[ "$create_private_runners" == "yes" ]]; then
     RUNNERS_RESOURCE_GROUP=""
     RUNNERS_LOCATION=""
-    RUNNERS_VNET=""
     RUNNERS_SUBNET=""
     RUNNERS_COUNT=""
     RUNNERS_PUBLIC_KEY_PATH=""
@@ -134,8 +133,7 @@ configure_orchestrator() {
 
     _prompt_input "Enter the name of an existing resource group to deploy the runners to" RUNNERS_RESOURCE_GROUP
     _select_list_no_display RUNNERS_LOCATION "Enter an Azure Location to deploy the runners to (enter 'list' to view all available locations)" "$AZURE_REGIONS" "location"
-    _prompt_input "Enter the name of an existing virtual network to deploy the runners to" RUNNERS_VNET
-    _prompt_input "Enter the name of an existing subnet to deploy the runners to" RUNNERS_SUBNET
+    _prompt_input "Enter the full resource id of an existing subnet to deploy the runners to" RUNNERS_SUBNET
     _prompt_input "Enter the path to the public key to use for the runners" RUNNERS_PUBLIC_KEY_PATH
     _select_number RUNNERS_COUNT "Number of runners to create"
   fi

--- a/scripts/install/cli/symphony
+++ b/scripts/install/cli/symphony
@@ -139,6 +139,28 @@ configure_orchestrator() {
   configure_repo
   configure_credentials
 
+  local create_private_runners=""
+  _select_yes_no create_private_runners "Create private runners:"
+  if [[ "$create_private_runners" == "yes" ]]; then
+    RUNNERS_RESOURCE_GROUP=""
+    RUNNERS_LOCATION=""
+    RUNNERS_VNET=""
+    RUNNERS_SUBNET=""
+    RUNNERS_COUNT=""
+    RUNNERS_PUBLIC_KEY_PATH=""
+
+    AZURE_REGIONS=$(az account list-locations -o json | jq -r '.[].name' | sort)
+
+    _prompt_input "Enter the name of an existing resource group to deploy the runners to" RUNNERS_RESOURCE_GROUP
+    _select_list_no_display RUNNERS_LOCATION "Enter an Azure Location to deploy the runners to (enter 'list' to view all available locations)" "$AZURE_REGIONS" "location"
+    _prompt_input "Enter the name of an existing virtual network to deploy the runners to" RUNNERS_VNET
+    _prompt_input "Enter the name of an existing subnet to deploy the runners to" RUNNERS_SUBNET
+    _prompt_input "Enter the path to the public key to use for the runners" RUNNERS_PUBLIC_KEY_PATH
+    _select_number RUNNERS_COUNT "Number of runners to create"
+
+    configure_runners
+  fi
+
   # Update the resource names
   git add .
   git commit -m "Initial commit"

--- a/scripts/install/cli/symphony
+++ b/scripts/install/cli/symphony
@@ -120,6 +120,26 @@ configure_orchestrator() {
   printEnvironment
   load_inputs
 
+  local create_private_runners=""
+  _select_yes_no create_private_runners "Create private runners:"
+  if [[ "$create_private_runners" == "yes" ]]; then
+    RUNNERS_RESOURCE_GROUP=""
+    RUNNERS_LOCATION=""
+    RUNNERS_VNET=""
+    RUNNERS_SUBNET=""
+    RUNNERS_COUNT=""
+    RUNNERS_PUBLIC_KEY_PATH=""
+
+    AZURE_REGIONS=$(az account list-locations -o json | jq -r '.[].name' | sort)
+
+    _prompt_input "Enter the name of an existing resource group to deploy the runners to" RUNNERS_RESOURCE_GROUP
+    _select_list_no_display RUNNERS_LOCATION "Enter an Azure Location to deploy the runners to (enter 'list' to view all available locations)" "$AZURE_REGIONS" "location"
+    _prompt_input "Enter the name of an existing virtual network to deploy the runners to" RUNNERS_VNET
+    _prompt_input "Enter the name of an existing subnet to deploy the runners to" RUNNERS_SUBNET
+    _prompt_input "Enter the path to the public key to use for the runners" RUNNERS_PUBLIC_KEY_PATH
+    _select_number RUNNERS_COUNT "Number of runners to create"
+  fi
+
   # remove unused files
   remove_yaml
   if [ "$IACTOOL" == "bicep" ]; then
@@ -139,25 +159,7 @@ configure_orchestrator() {
   configure_repo
   configure_credentials
 
-  local create_private_runners=""
-  _select_yes_no create_private_runners "Create private runners:"
   if [[ "$create_private_runners" == "yes" ]]; then
-    RUNNERS_RESOURCE_GROUP=""
-    RUNNERS_LOCATION=""
-    RUNNERS_VNET=""
-    RUNNERS_SUBNET=""
-    RUNNERS_COUNT=""
-    RUNNERS_PUBLIC_KEY_PATH=""
-
-    AZURE_REGIONS=$(az account list-locations -o json | jq -r '.[].name' | sort)
-
-    _prompt_input "Enter the name of an existing resource group to deploy the runners to" RUNNERS_RESOURCE_GROUP
-    _select_list_no_display RUNNERS_LOCATION "Enter an Azure Location to deploy the runners to (enter 'list' to view all available locations)" "$AZURE_REGIONS" "location"
-    _prompt_input "Enter the name of an existing virtual network to deploy the runners to" RUNNERS_VNET
-    _prompt_input "Enter the name of an existing subnet to deploy the runners to" RUNNERS_SUBNET
-    _prompt_input "Enter the path to the public key to use for the runners" RUNNERS_PUBLIC_KEY_PATH
-    _select_number RUNNERS_COUNT "Number of runners to create"
-
     configure_runners
   fi
 

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -185,7 +185,6 @@ function configure_runners {
       AZDO_PAT \
       RUNNERS_RESOURCE_GROUP \
       RUNNERS_LOCATION \
-      RUNNERS_VNET \
       RUNNERS_SUBNET \
       RUNNERS_PUBLIC_KEY_PATH)
   for var in "${REQUIRED_VARS[@]}"; do
@@ -210,8 +209,8 @@ function configure_runners {
   # Optional parameter: Image (default: Ubuntu2404)
   RUNNERS_AZURE_IMAGE=${RUNNERS_AZURE_IMAGE:-Ubuntu2404}
 
-  # Optional parameter: VM name (default: symphony-runner)
-  RUNNERS_VM_NAME=${RUNNERS_VM_NAME:-symphony-runner}
+  # Optional parameter: VM name (default: symphony-azdo-runner)
+  RUNNERS_VM_NAME=${RUNNERS_VM_NAME:-symphony-azdo-runner}-${AZDO_PROJECT_NAME}
 
   # Optional parameter: VM username (default: azureuser)
   RUNNERS_VM_USERNAME=${RUNNERS_VM_USERNAME:-azureuser}
@@ -288,10 +287,9 @@ EOF
     --size \"$RUNNERS_AZURE_VM_SIZE\" \
     --admin-username \"$RUNNERS_VM_USERNAME\" \
     --ssh-key-values \"@$RUNNERS_PUBLIC_KEY_PATH\" \
-    --vnet-name \"$RUNNERS_AZURE_VNET\" \
     --subnet \"$RUNNERS_AZURE_SUBNET\" \
-    --custom-data cloud-init.yaml \
-    --no-wait"
+    --nsg \"\" \
+    --custom-data cloud-init.yaml"
 
   eval $vm_create_command
 

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -228,6 +228,7 @@ function configure_runners {
     - uidmap
     - unzip
     - docker.io
+    - build-essential
 
   write_files:
     - path: /agent-install.sh

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -168,6 +168,17 @@ function configure_repo {
 }
 
 function configure_runners {
+  # Replace in all files in ./.azure-pipelines "runs-on: ubuntu-latest" with "runs-on: self-hosted"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+      for file in ./.azure-pipelines/*; do
+          sed -i '' -E 's/([[:space:]]*)vmImage: \$\(agentImage\)([[:space:]]*)/\1name: 'Default'\2/g' "$file"
+      done
+  else
+      for file in ./.azure-pipelines/*; do
+          sed -i -E 's/([[:space:]]*)vmImage: \$\(agentImage\)([[:space:]]*)/\1name: 'Default'\2/g' "$file"
+      done
+  fi
+
   # Verify that required variables exist
   local REQUIRED_VARS=(\
       AZDO_ORG_URI \

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -287,6 +287,7 @@ EOF
     --nsg \"\" \
     --custom-data cloud-init.yaml"
 
+  _debug "Running command: $vm_create_command"
   eval $vm_create_command
 
   rm cloud-init.yaml

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -317,7 +317,7 @@ function create_pipelines_terraform() {
   pipelineVariables=$(_get_pipeline_var_defintion environmentName dev true)
 
   pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion goVersion 1.18.1 true)"
-  pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion terraformVersion 1.6.2 true)"
+  pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion terraformVersion 1.11.0 true)"
   pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion runLayerTest false true)"
   pipelineVariables="$pipelineVariables, $(_get_pipeline_var_defintion runBackupState true true)"
   _create_pipeline "CI-Deploy" "/.azure-pipelines/pipeline.ci.terraform.yml" "Deploy" "${pipelineVariables}" "${AZDO_PROJECT_NAME}"

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -38,6 +38,40 @@ function load_inputs {
   fi
 
   if [ -z "$AZDO_PAT" ]; then
+    # If on PAAS, ask to use az cli credentials instead of an actual PAT
+    if [ "$INSTALL_TYPE" == "PAAS" ]; then
+
+      local use_az_cli_credentials_azdo=""
+      _select_yes_no use_az_cli_credentials_azdo "Use Azure CLI credentials for Azure DevOps" "true"
+
+      if [ "$use_az_cli_credentials_azdo" == "yes" ]; then
+        _information "Retrieving a short lived access token for AzDO..."
+
+        # If AZDO_TENANT_ID is set, use it
+        if [ -n "$AZDO_TENANT_ID" ]; then
+          tenant_id=$AZDO_TENANT_ID
+        else
+          # Try to get the managedByTenantId first
+          local tenant_id=$(az account show --query managedByTenants[0].tenantId -o tsv)
+
+          # If that is empty, fallback to the tenantId
+          if [ -z "$tenant_id" ]; then
+              tenant_id=$(az account show --query tenantId -o tsv)
+          fi
+        fi
+
+        _information "Using tenant_id: $tenant_id"
+
+        local azdo_resource_id="499b84ac-1321-427f-aa17-267ca6975798"
+
+        AZDO_PAT=$(az account get-access-token --tenant $tenant_id --resource $azdo_resource_id --query accessToken --output tsv)
+
+        _information "Retrieved an access token for AzDO via az cli!"
+      fi
+    fi
+  fi
+
+  if [ -z "$AZDO_PAT" ]; then
     _prompt_input "Enter Azure Devops PAT" AZDO_PAT
   fi
 }
@@ -133,6 +167,128 @@ function configure_repo {
   _success "Project '${AZDO_PROJECT_NAME}' created."
 }
 
+function configure_runners {
+  # Verify that required variables exist
+  local REQUIRED_VARS=(\
+      AZDO_ORG_URI \
+      AZDO_PAT \
+      RUNNERS_RESOURCE_GROUP \
+      RUNNERS_LOCATION \
+      RUNNERS_VNET \
+      RUNNERS_SUBNET \
+      RUNNERS_PUBLIC_KEY_PATH)
+  for var in "${REQUIRED_VARS[@]}"; do
+      if [[ -z "${!var}" ]]; then
+          _error "The variable '$var' is not defined. Aborting."
+          exit 1
+      fi
+  done
+
+  # Validate that the file exists
+  if [[ ! -f "$RUNNERS_PUBLIC_KEY_PATH" ]]; then
+      _error "The specified public key file '$RUNNERS_PUBLIC_KEY_PATH' does not exist. Aborting."
+      exit 1
+  fi
+
+  # Optional parameter: VM size (default: Standard_D2s_v3)
+  RUNNERS_AZURE_VM_SIZE=${RUNNERS_AZURE_VM_SIZE:-Standard_D2s_v3}
+
+  # Optional parameter: Number of runners to launch (default: 1)
+  RUNNERS_COUNT=${RUNNERS_COUNT:-1}
+
+  # Optional parameter: Image (default: Ubuntu2404)
+  RUNNERS_AZURE_IMAGE=${RUNNERS_AZURE_IMAGE:-Ubuntu2404}
+
+  # Optional parameter: VM name (default: symphony-runner)
+  RUNNERS_VM_NAME=${RUNNERS_VM_NAME:-symphony-runner}
+
+  # Optional parameter: VM username (default: azureuser)
+  RUNNERS_VM_USERNAME=${RUNNERS_VM_USERNAME:-azureuser}
+
+  local token=$AZDO_PAT
+
+  # Generate the cloud-init file (cloud-init.yaml)
+  cat > cloud-init.yaml <<EOF
+  #cloud-config
+  package_update: true
+
+  packages:
+    - curl
+    - tar
+    - uidmap
+    - unzip
+    - docker.io
+
+  write_files:
+    - path: /agent-install.sh
+      permissions: '0777'
+      content: |
+          #!/usr/bin/env bash
+
+          cd /home/$RUNNERS_VM_USERNAME
+
+          # Enable Docker
+          sudo systemctl enable --now docker
+          sudo usermod -aG docker $RUNNERS_VM_USERNAME
+
+          echo 'if [ ! -f ~/.config/docker-rootless-done ]; then
+              dockerd-rootless-setuptool.sh install
+              touch ~/.config/docker-rootless-done
+          fi' >> ~/.bashrc
+
+          # Install AzDO runner
+
+          for i in \$(seq 1 ${RUNNERS_COUNT}); do
+              RUNNER_DIR="/home/$RUNNERS_VM_USERNAME/azdo-runner-\$i"
+              echo "Configuring runner in \$RUNNER_DIR..."
+              mkdir -p "\$RUNNER_DIR"
+              cd "\$RUNNER_DIR"
+
+              # Download a fixed version of the runner
+              RUNNER_VERSION="4.251.0"
+              curl -O -L "https://vstsagentpackage.azureedge.net/agent/\${RUNNER_VERSION}/vsts-agent-linux-x64-\${RUNNER_VERSION}.tar.gz"
+              tar xzf "vsts-agent-linux-x64-\${RUNNER_VERSION}.tar.gz"
+
+              # Configure the runner non-interactively using its respective token
+              ./config.sh --unattended --url "${AZDO_ORG_URI}" --auth pat --token "${token}" --pool "Default" --agent "agent-\$i" --acceptTeeEula
+
+              # Install the service
+              sudo ./svc.sh install
+
+              # Start the runner in the background
+              sudo ./svc.sh start
+
+              # Return to the home directory for the next iteration
+              cd /home/$RUNNERS_VM_USERNAME
+          done
+  runcmd:
+    - sudo -u $RUNNERS_VM_USERNAME /agent-install.sh
+EOF
+
+  echo "cloud-init.yaml file generated."
+
+  # Create the VM using Azure CLI with the specified parameters and cloud-init
+  _information "Creating the VM in Azure..."
+  vm_create_command="az vm create \
+    --resource-group \"$RUNNERS_RESOURCE_GROUP\" \
+    --name \"$RUNNERS_VM_NAME\" \
+    --location \"$RUNNERS_LOCATION\" \
+    --image \"$RUNNERS_AZURE_IMAGE\" \
+    --size \"$RUNNERS_AZURE_VM_SIZE\" \
+    --admin-username \"$RUNNERS_VM_USERNAME\" \
+    --ssh-key-values \"@$RUNNERS_PUBLIC_KEY_PATH\" \
+    --vnet-name \"$RUNNERS_AZURE_VNET\" \
+    --subnet \"$RUNNERS_AZURE_SUBNET\" \
+    --custom-data cloud-init.yaml \
+    --no-wait"
+
+  eval $vm_create_command
+
+  rm cloud-init.yaml
+
+  _information "The VM creation request has been submitted."
+}
+
 function configure_credentials {
   _information "Configure Service Connections"
   _create_arm_svc_connection
@@ -212,7 +368,7 @@ function _create_arm_svc_connection() {
   sc_subject=$(jq <"$AZDO_TEMP_LOG_PATH/casc.json" -r '.authorization.parameters.workloadIdentityFederationSubject')
 
 
-  # Configuring federated identity for Github Actions, based on repo name and environment name
+  # Configuring federated identity for Azure DevOps Pipelines, based on repo name and environment name
   parameters=$(cat <<EOF
   {
     "name": "symphony-credential-${AZDO_PROJECT_ID}",

--- a/scripts/install/providers/azdo/azdo.sh
+++ b/scripts/install/providers/azdo/azdo.sh
@@ -242,11 +242,6 @@ function configure_runners {
           sudo systemctl enable --now docker
           sudo usermod -aG docker $RUNNERS_VM_USERNAME
 
-          echo 'if [ ! -f ~/.config/docker-rootless-done ]; then
-              dockerd-rootless-setuptool.sh install
-              touch ~/.config/docker-rootless-done
-          fi' >> ~/.bashrc
-
           # Install AzDO runner
 
           for i in \$(seq 1 ${RUNNERS_COUNT}); do

--- a/scripts/install/providers/github/github.sh
+++ b/scripts/install/providers/github/github.sh
@@ -158,6 +158,7 @@ function configure_runners {
     - uidmap
     - unzip
     - docker.io
+    - build-essential
 
   write_files:
     - path: /runner-install.sh

--- a/scripts/install/providers/github/github.sh
+++ b/scripts/install/providers/github/github.sh
@@ -94,7 +94,6 @@ function configure_runners {
       GH_Repo_NAME \
       RUNNERS_RESOURCE_GROUP \
       RUNNERS_LOCATION \
-      RUNNERS_VNET \
       RUNNERS_SUBNET \
       RUNNERS_PUBLIC_KEY_PATH)
   for var in "${REQUIRED_VARS[@]}"; do
@@ -119,8 +118,8 @@ function configure_runners {
   # Optional parameter: Image (default: Ubuntu2404)
   RUNNERS_AZURE_IMAGE=${RUNNERS_AZURE_IMAGE:-Ubuntu2404}
 
-  # Optional parameter: VM name (default: symphony-runner)
-  RUNNERS_VM_NAME=${RUNNERS_VM_NAME:-symphony-runner}
+  # Optional parameter: VM name (default: symphony-github-runner)
+  RUNNERS_VM_NAME=${RUNNERS_VM_NAME:-symphony-github-runner}-${GH_Repo_NAME}
 
   # Optional parameter: VM username (default: azureuser)
   RUNNERS_VM_USERNAME=${RUNNERS_VM_USERNAME:-azureuser}
@@ -216,10 +215,9 @@ EOF
     --size \"$RUNNERS_AZURE_VM_SIZE\" \
     --admin-username \"$RUNNERS_VM_USERNAME\" \
     --ssh-key-values \"@$RUNNERS_PUBLIC_KEY_PATH\" \
-    --vnet-name \"$RUNNERS_AZURE_VNET\" \
     --subnet \"$RUNNERS_AZURE_SUBNET\" \
-    --custom-data cloud-init.yaml \
-    --no-wait"
+    --nsg \"\" \
+    --custom-data cloud-init.yaml"
 
   eval $vm_create_command
 

--- a/scripts/install/providers/github/github.sh
+++ b/scripts/install/providers/github/github.sh
@@ -77,6 +77,17 @@ function configure_repo {
 }
 
 function configure_runners {
+  # Replace in all files in ./.github/workflows "runs-on: ubuntu-latest" with "runs-on: self-hosted"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+      for file in ./.github/workflows/*; do
+          sed -i '' -E 's/([[:space:]]*)runs-on: ubuntu-latest([[:space:]]*)/\1runs-on: self-hosted\2/g' "$file"
+      done
+  else
+      for file in ./.github/workflows/*; do
+          sed -i -E 's/([[:space:]]*)runs-on: ubuntu-latest([[:space:]]*)/\1runs-on: self-hosted\2/g' "$file"
+      done
+  fi
+
   # Verify that required variables exist
   local REQUIRED_VARS=(\
       GH_ORG_NAME \

--- a/scripts/install/providers/github/github.sh
+++ b/scripts/install/providers/github/github.sh
@@ -33,16 +33,21 @@ function load_inputs {
     _select_yes_no IS_Private_GH_Repo "Is GitHub Repo Private (yes/no)" "false"
   fi
 
-  if [ -z "$GH_PAT" ]; then
-    _prompt_input "Enter GitHub PAT" GH_PAT
-  fi
-
   $(gh auth status >/dev/null 2>&1)
   code=$?
   if [ "$code" == "0" ]; then
     _information "GitHub Cli is already logged in. Bootstrap with existing authorization."
   else
-    echo "$GH_PAT" | gh auth login --with-token
+    local login_to_github
+    _select_yes_no login_to_github "Do an interactive login to the gh cli" "true"
+    if [ "$login_to_github" == "true" ]; then
+      gh auth login
+    else
+      if [ -z "$GH_PAT" ]; then
+        _prompt_input "Enter GitHub PAT" GH_PAT
+      fi
+      echo "$GH_PAT" | gh auth login --with-token
+    fi
   fi
 }
 
@@ -54,7 +59,10 @@ function configure_repo {
     visibility="--private"
   fi
 
-  command="gh repo create $GH_ORG_NAME/$GH_Repo_NAME $visibility"
+  git init
+  git branch -m main
+
+  command="gh repo create $GH_ORG_NAME/$GH_Repo_NAME $visibility --source=."
   _information "running - $command"
   eval "$command"
 
@@ -65,13 +73,148 @@ function configure_repo {
   _debug "$CODE_REPO_GIT_HTTP_URL"
   _debug "$CODE_REPO_ID"
 
-  # Configure remote for local git repo
-  remoteWithCreds="https://${GH_PAT}@github.com/${GH_ORG_NAME}/${GH_Repo_NAME}.git"
-  git init
-  git branch -m main
-  git remote add origin "$remoteWithCreds"
-
   _success "Repo '${GH_Repo_NAME}' created."
+}
+
+function configure_runners {
+  # Verify that required variables exist
+  local REQUIRED_VARS=(\
+      GH_ORG_NAME \
+      GH_Repo_NAME \
+      RUNNERS_RESOURCE_GROUP \
+      RUNNERS_LOCATION \
+      RUNNERS_VNET \
+      RUNNERS_SUBNET \
+      RUNNERS_PUBLIC_KEY_PATH)
+  for var in "${REQUIRED_VARS[@]}"; do
+      if [[ -z "${!var}" ]]; then
+          _error "The variable '$var' is not defined. Aborting."
+          exit 1
+      fi
+  done
+
+  # Validate that the file exists
+  if [[ ! -f "$RUNNERS_PUBLIC_KEY_PATH" ]]; then
+      _error "The specified public key file '$RUNNERS_PUBLIC_KEY_PATH' does not exist. Aborting."
+      exit 1
+  fi
+
+  # Optional parameter: VM size (default: Standard_D2s_v3)
+  RUNNERS_AZURE_VM_SIZE=${RUNNERS_AZURE_VM_SIZE:-Standard_D2s_v3}
+
+  # Optional parameter: Number of runners to launch (default: 1)
+  RUNNERS_COUNT=${RUNNERS_COUNT:-1}
+
+  # Optional parameter: Image (default: Ubuntu2404)
+  RUNNERS_AZURE_IMAGE=${RUNNERS_AZURE_IMAGE:-Ubuntu2404}
+
+  # Optional parameter: VM name (default: symphony-runner)
+  RUNNERS_VM_NAME=${RUNNERS_VM_NAME:-symphony-runner}
+
+  # Optional parameter: VM username (default: azureuser)
+  RUNNERS_VM_USERNAME=${RUNNERS_VM_USERNAME:-azureuser}
+
+  # Retrieve multiple GitHub runner registration tokens
+  _information "Retrieving ${RUNNERS_COUNT} GitHub runner registration tokens..."
+  local tokens=()
+
+  for i in $(seq 1 "$RUNNERS_COUNT"); do
+      local token=$(gh api -X POST /repos/${GH_ORG_NAME}/${GH_Repo_NAME}/actions/runners/registration-token -q .token)
+
+      if [[ "$token" == "null" || -z "$token" ]]; then
+          _error "Error: Failed to retrieve token for runner $i."
+          exit 1
+      fi
+
+      tokens+=("$token")
+
+      _information "Sleeping for 1 second to avoid repeated token requests..."
+      sleep 1
+  done
+
+  _information "All tokens retrieved successfully."
+
+  # Convert tokens array into a space-separated string
+  local token_string=$(IFS=" " ; echo "${tokens[*]}")
+
+  # Generate the cloud-init file (cloud-init.yaml)
+  cat > cloud-init.yaml <<EOF
+  #cloud-config
+  package_update: true
+
+  packages:
+    - curl
+    - tar
+    - uidmap
+    - unzip
+    - docker.io
+
+  write_files:
+    - path: /runner-install.sh
+      permissions: '0777'
+      content: |
+          #!/usr/bin/env bash
+
+          cd /home/$RUNNERS_VM_USERNAME
+
+          # Enable Docker
+          sudo systemctl enable --now docker
+          sudo usermod -aG docker $RUNNERS_VM_USERNAME
+
+          # Install GitHub runner
+
+          # Tokens from cloud-init
+          TOKENS=(${token_string})
+
+          for i in \$(seq 1 ${RUNNERS_COUNT}); do
+              RUNNER_DIR="/home/$RUNNERS_VM_USERNAME/github-runner-\$i"
+              echo "Configuring runner in \$RUNNER_DIR..."
+              mkdir -p "\$RUNNER_DIR"
+              cd "\$RUNNER_DIR"
+
+              # Download a fixed version of the runner
+              RUNNER_VERSION="2.322.0"
+              curl -O -L "https://github.com/actions/runner/releases/download/v\${RUNNER_VERSION}/actions-runner-linux-x64-\${RUNNER_VERSION}.tar.gz"
+              tar xzf "actions-runner-linux-x64-\${RUNNER_VERSION}.tar.gz"
+
+              # Configure the runner non-interactively using its respective token
+              ./config.sh --url "https://github.com/${GH_ORG_NAME}/${GH_Repo_NAME}" --token "\${TOKENS[\$((i-1))]}" --unattended --name "runner-\$i"
+
+              # Install the service
+              sudo ./svc.sh install
+
+              # Start the runner in the background
+              sudo ./svc.sh start
+
+              # Return to the home directory for the next iteration
+              cd /home/$RUNNERS_VM_USERNAME
+          done
+  runcmd:
+    - sudo -u $RUNNERS_VM_USERNAME /runner-install.sh
+EOF
+
+  _information "cloud-init.yaml file generated."
+
+  # Create the VM using Azure CLI with the specified parameters and cloud-init
+  _information "Creating the VM in Azure..."
+  vm_create_command="az vm create \
+    --resource-group \"$RUNNERS_RESOURCE_GROUP\" \
+    --name \"$RUNNERS_VM_NAME\" \
+    --location \"$RUNNERS_LOCATION\" \
+    --image \"$RUNNERS_AZURE_IMAGE\" \
+    --size \"$RUNNERS_AZURE_VM_SIZE\" \
+    --admin-username \"$RUNNERS_VM_USERNAME\" \
+    --ssh-key-values \"@$RUNNERS_PUBLIC_KEY_PATH\" \
+    --vnet-name \"$RUNNERS_AZURE_VNET\" \
+    --subnet \"$RUNNERS_AZURE_SUBNET\" \
+    --custom-data cloud-init.yaml \
+    --no-wait"
+
+  eval $vm_create_command
+
+  rm cloud-init.yaml
+
+  _information "The VM creation request has been submitted."
 }
 
 function _add_federated_credential {

--- a/scripts/install/providers/github/github.sh
+++ b/scripts/install/providers/github/github.sh
@@ -220,6 +220,7 @@ EOF
     --nsg \"\" \
     --custom-data cloud-init.yaml"
 
+  _debug "Running command: $vm_create_command"
   eval $vm_create_command
 
   rm cloud-init.yaml

--- a/scripts/install/provision.sh
+++ b/scripts/install/provision.sh
@@ -231,7 +231,7 @@ create_sp() {
   local _scope="${3}"
 
   sleep 60
-  sp_object=$(az ad sp create-for-rbac --display-name "${_display_name}" --role "${_role}" --scopes "${_scope}")
+  sp_object=$(az ad sp create-for-rbac --display-name "${_display_name}" --role "${_role}" --scopes "${_scope}" --create-cert)
 
   echo "${sp_object}"
 }

--- a/scripts/orchestrators/_setup_helpers.sh
+++ b/scripts/orchestrators/_setup_helpers.sh
@@ -41,7 +41,7 @@ find_version_from_git_tags() {
     else
       last_part="${escaped_separator}[0-9]+"
     fi
-    local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+    local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}(-[A-Za-z0-9]+)*$"
     local version_list="$(git ls-remote --tags "${repository}" | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
     if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
       declare -g "${variable_name}"="$(echo "${version_list}" | head -n 1)"

--- a/scripts/orchestrators/iac.tf.sh
+++ b/scripts/orchestrators/iac.tf.sh
@@ -26,6 +26,7 @@ set_arm_env_vars() {
   export ARM_CLIENT_ID=$client_id
   export ARM_TENANT_ID=$tenant_id
   export ARM_USE_OIDC=true
+  export ARM_USE_AZUREAD=true
   export ARM_STORAGE_USE_AZUREAD=true
 }
 
@@ -49,11 +50,6 @@ init() {
             -backend-config=container_name=${container_name} \
             -backend-config=key=${key} \
             -backend-config=resource_group_name=${resource_group_name} \
-            -backend-config=subscription_id=${ARM_SUBSCRIPTION_ID} \
-            -backend-config=tenant_id=${ARM_TENANT_ID} \
-            -backend-config=client_id=${ARM_CLIENT_ID} \
-            -backend-config=use_oidc=true \
-            -backend-config=use_azuread_auth=true \
             -reconfigure"
 
     terraform init \
@@ -61,11 +57,6 @@ init() {
       -backend-config=container_name=${container_name} \
       -backend-config=key=${key} \
       -backend-config=resource_group_name=${resource_group_name} \
-      -backend-config=subscription_id=${ARM_SUBSCRIPTION_ID} \
-      -backend-config=tenant_id=${ARM_TENANT_ID} \
-      -backend-config=client_id=${ARM_CLIENT_ID} \
-      -backend-config=use_oidc=true \
-      -backend-config=use_azuread_auth=true \
       -reconfigure
   fi
 }

--- a/scripts/orchestrators/iac.tf.sh
+++ b/scripts/orchestrators/iac.tf.sh
@@ -18,14 +18,9 @@ usage() {
 set_arm_env_vars() {
   # retrieve client_id, subscription_id, tenant_id from logged in user
   azaccount=$(az account show)
-  client_id=$(echo $azaccount | jq -r .user.name)
   subscription_id=$(echo $azaccount | jq -r .id)
-  tenant_id=$(echo $azaccount | jq -r .tenantId)
 
   export ARM_SUBSCRIPTION_ID=$subscription_id
-  export ARM_CLIENT_ID=$client_id
-  export ARM_TENANT_ID=$tenant_id
-  export ARM_USE_OIDC=true
   export ARM_USE_AZUREAD=true
   export ARM_STORAGE_USE_AZUREAD=true
 }

--- a/scripts/orchestrators/iac.tf.statebackup.sh
+++ b/scripts/orchestrators/iac.tf.statebackup.sh
@@ -12,4 +12,20 @@ sourceEndPoint=$(az storage account list -g "${STATE_RG}" --query "[?name=='$STA
 backupEndpoint=$(az storage account list -g $backupResourceGroup --query "[?name=='$STATE_STORAGE_ACCOUNT_BACKUP'].{endpointName:primaryEndpoints.blob}" -o tsv)
 
 echo "Copying remote state to container ${backupContainerName} in storage account $STATE_STORAGE_ACCOUNT_BACKUP located in resource group ${backupResourceGroup}"
+
+# Checking if azcopy is installed. Otherwise, install it manually because the version that the az cli installs
+# has some issues when trying to use the authentication with the az cli
+
+azCopyFilePath=$AZURE_CONFIG_DIR/bin/azcopy
+if [ ! -f "$azCopyFilePath" ]; then
+    echo "azcopy not found in $azCopyFilePath. Downloading..."
+    curl -L https://aka.ms/downloadazcopy-v10-linux -o azcopy_linux_amd64.tar.gz
+    tar -xf azcopy_linux_amd64.tar.gz
+
+    echo "Copying azcopy to $azCopyFilePath"
+    mkdir -p $AZURE_CONFIG_DIR/bin/
+    cp azcopy_linux_amd64*/azcopy $azCopyFilePath
+fi
+
+
 az storage copy --auth-mode login -s ${sourceEndPoint}${STATE_CONTAINER}/${ENVIRONMENT_NAME}/* -d ${backupEndpoint}${STATE_CONTAINER}/${ENVIRONMENT_NAME}/${backupContainerName} --recursive

--- a/scripts/orchestrators/iac.tf.test.sh
+++ b/scripts/orchestrators/iac.tf.test.sh
@@ -14,14 +14,9 @@ export container_name="${STATE_CONTAINER}"
 
 # retrieve client_id, subscription_id, tenant_id from logged in user
 azaccount=$(az account show)
-client_id=$(echo $azaccount | jq -r .user.name)
 subscription_id=$(echo $azaccount | jq -r .id)
-tenant_id=$(echo $azaccount | jq -r .tenantId)
 
 export ARM_SUBSCRIPTION_ID=$subscription_id
-export ARM_CLIENT_ID=$client_id
-export ARM_TENANT_ID=$tenant_id
-export ARM_USE_OIDC=true
 export ARM_USE_AZUREAD=true
 export ARM_STORAGE_USE_AZUREAD=true
 

--- a/scripts/orchestrators/iac.tf.test.sh
+++ b/scripts/orchestrators/iac.tf.test.sh
@@ -23,6 +23,7 @@ export ARM_CLIENT_ID=$client_id
 export ARM_TENANT_ID=$tenant_id
 export ARM_USE_OIDC=true
 export ARM_USE_AZUREAD=true
+export ARM_STORAGE_USE_AZUREAD=true
 
 if [[ "${TEST_TAG}" == "module_tests" ]]; then
   echo "Run tests with tag = module_tests"

--- a/scripts/orchestrators/setup-age.sh
+++ b/scripts/orchestrators/setup-age.sh
@@ -27,6 +27,6 @@ filename="age-v${VERSION}-linux-${os_architecture}.tar.gz"
 curl -sSL -o "${filename}" "https://github.com/FiloSottile/age/releases/download/v${VERSION}/${filename}"
 tar -xf "${filename}" age
 rm -f "${filename}"
-mv -f age/age /usr/local/bin/
-mv -f age/age-keygen /usr/local/bin/
+sudo mv -f age/age /usr/local/bin/
+sudo mv -f age/age-keygen /usr/local/bin/
 rm -rf age

--- a/scripts/orchestrators/setup-azcli.sh
+++ b/scripts/orchestrators/setup-azcli.sh
@@ -2,10 +2,14 @@
 
 # Syntax: ./setup-azcli.sh
 
-# Create a temporary directory for Azure CLI configuration isolation
-temp_dir=$(mktemp -d)
-export AZURE_CONFIG_DIR="$temp_dir"
-echo "AZURE_CONFIG_DIR=$AZURE_CONFIG_DIR" >> $GITHUB_ENV
+# If it's running as a Github action, Create a temporary directory
+# for Azure CLI configuration isolation
+
+if [ "$GITHUB_ACTIONS" == "true" ]; then
+  temp_dir=$(mktemp -d)
+  export AZURE_CONFIG_DIR="$temp_dir"
+  echo "AZURE_CONFIG_DIR=$AZURE_CONFIG_DIR" >> $GITHUB_ENV
+fi
 
 # check if azurecli is already installed
 if command -v az &>/dev/null; then

--- a/scripts/orchestrators/setup-azcli.sh
+++ b/scripts/orchestrators/setup-azcli.sh
@@ -2,6 +2,11 @@
 
 # Syntax: ./setup-azcli.sh
 
+# Create a temporary directory for Azure CLI configuration isolation
+temp_dir=$(mktemp -d)
+export AZURE_CONFIG_DIR="$temp_dir"
+echo "AZURE_CONFIG_DIR=$AZURE_CONFIG_DIR" >> $GITHUB_ENV
+
 # check if azurecli is already installed
 if command -v az &>/dev/null; then
   echo "Azure CLI is already installed"

--- a/scripts/orchestrators/setup-gitleaks.sh
+++ b/scripts/orchestrators/setup-gitleaks.sh
@@ -27,4 +27,4 @@ filename="gitleaks_${VERSION}_linux_${os_architecture}.tar.gz"
 curl -sSL -o "${filename}" "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/${filename}"
 tar -xf "${filename}" gitleaks
 rm -f "${filename}"
-mv -f gitleaks /usr/local/bin/
+sudo mv -f gitleaks /usr/local/bin/

--- a/scripts/orchestrators/setup-powershell.sh
+++ b/scripts/orchestrators/setup-powershell.sh
@@ -29,5 +29,5 @@ mkdir -p tmp/pwsh "${target_path}"
 cd tmp/pwsh
 curl -sSL -o "${filename}" "https://github.com/PowerShell/PowerShell/releases/download/v${VERSION}/${filename}"
 tar -xf "${filename}" -C "${target_path}"
-ln -s "${target_path}/pwsh" /usr/local/bin/pwsh
+sudo ln -s "${target_path}/pwsh" /usr/local/bin/pwsh
 rm -rf tmp/pwsh

--- a/scripts/orchestrators/setup-powershell.sh
+++ b/scripts/orchestrators/setup-powershell.sh
@@ -3,7 +3,8 @@
 # Syntax: ./setup-powershell.sh [version]
 
 # check if powershell is already installed
-if command -v pwsh &>/dev/null; then
+
+if which pwsh &>/dev/null; then
   echo "PowerShell is already installed"
   exit 0
 fi
@@ -13,21 +14,12 @@ source _helpers.sh
 source _setup_helpers.sh
 
 set -e
-VERSION="${1:-"latest"}"
 
-# Get OS architecture
-get_os_architecture "x64" "arm64" "arm32"
+_information "Installing PowerShell..."
 
-# Verify requested version is available, convert latest
-find_version_from_git_tags VERSION 'https://github.com/PowerShell/PowerShell'
+sudo apt install -y wget apt-transport-https software-properties-common
+wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt update
 
-_information "Downloading PowerShell..."
-
-filename="powershell-${VERSION}-linux-${os_architecture}.tar.gz"
-target_path="$(pwd)/powershell/$(echo ${VERSION} | grep -oE '[^\.]+' | head -n 1)"
-mkdir -p tmp/pwsh "${target_path}"
-cd tmp/pwsh
-curl -sSL -o "${filename}" "https://github.com/PowerShell/PowerShell/releases/download/v${VERSION}/${filename}"
-tar -xf "${filename}" -C "${target_path}"
-sudo ln -s "${target_path}/pwsh" /usr/local/bin/pwsh
-rm -rf tmp/pwsh
+sudo apt install -y powershell

--- a/scripts/orchestrators/setup-sops.sh
+++ b/scripts/orchestrators/setup-sops.sh
@@ -26,4 +26,4 @@ _information "Downloading SOPS..."
 filename="sops-v${VERSION}.linux.${os_architecture}"
 echo "${filename}"
 curl -sSL -o "${filename}" "https://github.com/mozilla/sops/releases/download/v${VERSION}/${filename}"
-mv -f "${filename}" /usr/local/bin/sops
+sudo mv -f "${filename}" /usr/local/bin/sops

--- a/scripts/orchestrators/setup-terraform.sh
+++ b/scripts/orchestrators/setup-terraform.sh
@@ -22,4 +22,4 @@ curl -sSL -o "${filename}" "https://releases.hashicorp.com/terraform/${VERSION}/
 unzip "${filename}"
 rm -f "${filename}"
 # ln -s "terraform" /usr/local/bin/terraform
-mv -f terraform /usr/local/bin/
+sudo mv -f terraform /usr/local/bin/

--- a/scripts/orchestrators/setup-tflint.sh
+++ b/scripts/orchestrators/setup-tflint.sh
@@ -27,4 +27,4 @@ filename="tflint_linux_${os_architecture}.zip"
 curl -sSL -o "${filename}" "https://github.com/terraform-linters/tflint/releases/download/v${VERSION}/${filename}"
 unzip "${filename}"
 rm -f "${filename}"
-mv -f tflint /usr/local/bin/
+sudo mv -f tflint /usr/local/bin/

--- a/scripts/utilities/shell_inputs.sh
+++ b/scripts/utilities/shell_inputs.sh
@@ -73,6 +73,22 @@ function _select_list() {
   printf "\e[0m"
 }
 
+function _select_number() {
+  variable="$1"
+  message="${2:-Please enter a number between 1 and 9}"
+
+  _prompt "> $message : "
+  read -r input
+  re='^[1-9]$'
+  while ! [[ "$input" =~ $re ]]; do
+    _error "$input is not a valid value. Please enter a number from 1 to 9."
+    _prompt "$message"
+    read -r input
+  done
+  eval "$variable=$input"
+  printf "\e[0m"
+}
+
 function _select_yes_no() {
   variable="$1"
   message="${2:-Please make a selection}"


### PR DESCRIPTION
This PR does the following things:

- Adds support for the creation and configuration of private runners for both AzDO and GitHub workflows.
- Removes the need for a Github PAT or an AzDO PAT, during pipeline config, as long as the `gh` cli or `az` cli are signed in.
- Fixes several issues during the tooling setup on brand new private runners
- Moves to Terraform 1.11.0 as the required version, since it has much better support for azurerm backend using az cli credentials. Leveraging this simplifies a lot the authentication process for terraform pipelines, avoiding the need for specific auth code or env variables. 

Fixes #298, #274 