### PR TITLE
Update storage account name in deployment configurations

### DIFF
--- a/env/terraform/dev/03_config_01_deployment.tfvars.json
+++ b/env/terraform/dev/03_config_01_deployment.tfvars.json
@@ -1,8 +1,8 @@
 {
-    "env": "dev",
-    "location": "westus",
-    "rs_resource_group_name": "devops-symphony-362",
-    "rs_storage_account_name": "symphonyremotestate360",
-    "rs_container_name": "tfstate",
-    "rs_container_key": "02_storage/01_deployment.tfstate"
+  "env": "dev",
+  "location": "westus",
+  "rs_resource_group_name": "devops-symphony-362",
+  "rs_storage_account_name": "symphonyremotestate361",
+  "rs_container_name": "tfstate",
+  "rs_container_key": "02_storage/01_deployment.tfstate"
 }

--- a/env/terraform/pr/03_config_01_deployment.tfvars.json
+++ b/env/terraform/pr/03_config_01_deployment.tfvars.json
@@ -1,7 +1,7 @@
 {
   "location": "westus",
   "rs_resource_group_name": "devops-symphony-362",
-  "rs_storage_account_name": "symphonyremotestate360",
+  "rs_storage_account_name": "symphonyremotestate361",
   "rs_container_name": "tfstate",
   "rs_container_key": "02_storage/01_deployment.tfstate"
 }

--- a/env/terraform/prod/03_config_01_deployment.tfvars.json
+++ b/env/terraform/prod/03_config_01_deployment.tfvars.json
@@ -2,7 +2,7 @@
     "env": "prod",
     "location": "westus",
     "rs_resource_group_name": "devops-symphony-362",
-    "rs_storage_account_name": "symphonyremotestate360",
+    "rs_storage_account_name": "symphonyremotestate361",
     "rs_container_name": "tfstate",
     "rs_container_key": "02_storage/01_deployment.tfstate"
 }

--- a/scripts/install/cli/symphony
+++ b/scripts/install/cli/symphony
@@ -180,7 +180,7 @@ configure_orchestrator() {
     create_pipelines_bicep
   else
     # Update SA state Name
-    eval "git grep -l 'symphonyremotestate360' | xargs $sedCommand \"s/symphonyremotestate360/${SYMPHONY_SA_STATE_NAME}/g\""
+    eval "git grep -l 'symphonyremotestate361' | xargs $sedCommand \"s/symphonyremotestate361/${SYMPHONY_SA_STATE_NAME}/g\""
     create_pipelines_terraform
   fi
 


### PR DESCRIPTION
This PR updates the default storage account name used for the remote state workflows in deployment configurations

Resolves #305 