### PR TITLE
Security : Remove unsafe use of pull_request_target and stop persisting GITHUB_TOKEN on checkout

### DIFF
--- a/.github/workflows/template.bicep.cleanup.yml
+++ b/.github/workflows/template.bicep.cleanup.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.bicep.destroy.yml
+++ b/.github/workflows/template.bicep.destroy.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.bicep.previewdeploy.yml
+++ b/.github/workflows/template.bicep.previewdeploy.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.bicep.test.yml
+++ b/.github/workflows/template.bicep.test.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.bicep.validate.yml
+++ b/.github/workflows/template.bicep.validate.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.queryevents.yml
+++ b/.github/workflows/template.queryevents.yml
@@ -34,6 +34,8 @@ jobs:
       events: ${{ steps.QueryEvents.outputs.events }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: azure/login@v2
         name: Run Azure Login

--- a/.github/workflows/template.storeevent.yml
+++ b/.github/workflows/template.storeevent.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: azure/login@v2
         name: Run Azure Login

--- a/.github/workflows/template.terraform.cleanup.yml
+++ b/.github/workflows/template.terraform.cleanup.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.terraform.destroy.yml
+++ b/.github/workflows/template.terraform.destroy.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.terraform.report.yml
+++ b/.github/workflows/template.terraform.report.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.terraform.test.yml
+++ b/.github/workflows/template.terraform.test.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/template.terraform.validate.yml
+++ b/.github/workflows/template.terraform.validate.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branchName }}
+          persist-credentials: false
 
       - name: Setup Toolset
         run: |

--- a/.github/workflows/workflow.pr.bicep.cleanup.yml
+++ b/.github/workflows/workflow.pr.bicep.cleanup.yml
@@ -2,7 +2,7 @@
 name: PR Cleanup Bicep
 
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches:
@@ -10,7 +10,6 @@ on: # yamllint disable-line rule:truthy
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
-
 
 permissions:
   id-token: write

--- a/.github/workflows/workflow.pr.bicep.yml
+++ b/.github/workflows/workflow.pr.bicep.yml
@@ -2,7 +2,7 @@
 name: PR Deployment
 
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/workflow.pr.checker.yml
+++ b/.github/workflows/workflow.pr.checker.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # If you use VALIDATE_ALL_CODEBASE = true, you can remove this line to improve performances
+          persist-credentials: false
 
       - name: 🧹 MegaLinter
         id: megalinter

--- a/.github/workflows/workflow.pr.terraform.cleanup.yml
+++ b/.github/workflows/workflow.pr.terraform.cleanup.yml
@@ -2,7 +2,7 @@
 name: PR Cleanup Terraform
 
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches:

--- a/.github/workflows/workflow.pr.terraform.yml
+++ b/.github/workflows/workflow.pr.terraform.yml
@@ -2,7 +2,7 @@
 name: PR Deployment
 
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
Description:
Current PR workflows use pull_request_target and persist credentials during checkout, which allows forked PRs to trigger trusted runs that can access secrets/ID tokens and push commits. This creates a high-risk vector for secret exfiltration and repo or cloud compromise.

Fix:

Replace or restrict pull_request_target:

Use pull_request for CI that needs to run contributor code.
Reserve pull_request_target only for non-code automation that does NOT check out or execute PR-provided code.
Prevent credential persistence:
Add persist-credentials: false to all actions/checkout steps.


Fixes #323 
Closes #323 